### PR TITLE
ISSUE-17 - Adds a `GetPublicUrlAsync` method to the FileManager.

### DIFF
--- a/src/Baseline.Filesystem.Adapters.S3/S3Adapter.File.cs
+++ b/src/Baseline.Filesystem.Adapters.S3/S3Adapter.File.cs
@@ -132,7 +132,7 @@ namespace Baseline.Filesystem.Adapters.S3
             CancellationToken cancellationToken
         )
         {
-            await EnsureFileExistsAsync(getFilePublicUrlRequest.FilePath, cancellationToken);
+            await EnsureFileExistsAsync(getFilePublicUrlRequest.FilePath, cancellationToken).ConfigureAwait(false);
 
             var expiry = getFilePublicUrlRequest.Expiry ?? DateTime.Today.AddDays(1);
 

--- a/src/Baseline.Filesystem.Adapters.S3/S3Adapter.File.cs
+++ b/src/Baseline.Filesystem.Adapters.S3/S3Adapter.File.cs
@@ -125,6 +125,28 @@ namespace Baseline.Filesystem.Adapters.S3
                 cancellationToken
             ).ConfigureAwait(false);
         }
+        
+        /// <inheritdoc />
+        public async Task<GetFilePublicUrlResponse> GetFilePublicUrlAsync(
+            GetFilePublicUrlRequest getFilePublicUrlRequest,
+            CancellationToken cancellationToken
+        )
+        {
+            await EnsureFileExistsAsync(getFilePublicUrlRequest.FilePath, cancellationToken);
+
+            var expiry = getFilePublicUrlRequest.Expiry ?? DateTime.Today.AddDays(1);
+
+            return new GetFilePublicUrlResponse
+            {
+                Expiry = expiry,
+                Url = _s3Client.GetPreSignedURL(new GetPreSignedUrlRequest
+                {
+                    BucketName = _adapterConfiguration.BucketName,
+                    Key = getFilePublicUrlRequest.FilePath.NormalisedPath,
+                    Expires = expiry
+                })
+            };
+        }
 
         /// <summary>
         /// Checks and returns whether a file exists. For use within methods that do their own validation.

--- a/src/Baseline.Filesystem/Baseline.Filesystem.csproj.DotSettings
+++ b/src/Baseline.Filesystem/Baseline.Filesystem.csproj.DotSettings
@@ -7,4 +7,6 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=representations/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=requests/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=requests_005Cdirectory/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=requests_005Cfile/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=requests_005Cfile/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=responses/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=responses_005Cfile/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Baseline.Filesystem/Contracts/IAdapter.cs
+++ b/src/Baseline.Filesystem/Contracts/IAdapter.cs
@@ -121,7 +121,18 @@ namespace Baseline.Filesystem
         /// The request containing information about what to write and to where.
         /// </param>
         /// <param name="cancellationToken">The cancellation token used to cancel any asynchronous tasks.</param>
-        /// <returns>An asynchronous task.</returns>
         Task WriteTextToFileAsync(WriteTextToFileRequest writeTextToFileRequest, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves a public URL for a file from the adapter's data store.
+        /// </summary>
+        /// <param name="getFilePublicUrlRequest">
+        /// The request containing information about what file to retrieve a public URL for.
+        /// </param>
+        /// <param name="cancellationToken">The cancellation token used to cancel any asynchronous tasks.</param>
+        Task<GetFilePublicUrlResponse> GetFilePublicUrlAsync(
+            GetFilePublicUrlRequest getFilePublicUrlRequest,
+            CancellationToken cancellationToken
+        );
     }
 }

--- a/src/Baseline.Filesystem/Contracts/IFileManager.cs
+++ b/src/Baseline.Filesystem/Contracts/IFileManager.cs
@@ -104,6 +104,21 @@ namespace Baseline.Filesystem
             string adapter = "default",
             CancellationToken cancellationToken = default
         );
+        
+        /// <summary>
+        /// Retrieves a publicly accessible URL for the file defined in the request.
+        /// </summary>
+        /// <param name="getFilePublicUrlRequest">
+        /// The request containing the information about the file to get the public URL for.
+        /// </param>
+        /// <param name="adapter">The adapter to get the public URL for the file from.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A response containing the public URL and related information of the file.</returns>
+        Task<GetFilePublicUrlResponse> GetPublicUrlAsync(
+            GetFilePublicUrlRequest getFilePublicUrlRequest,
+            string adapter = "default",
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
         /// Moves a file from one path in an adapter's storage to another, returning the information about the newly

--- a/src/Baseline.Filesystem/DirectoryManager.cs
+++ b/src/Baseline.Filesystem/DirectoryManager.cs
@@ -19,7 +19,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public Task<AdapterAwareDirectoryRepresentation> CopyAsync(
+        public async Task<AdapterAwareDirectoryRepresentation> CopyAsync(
             CopyDirectoryRequest copyDirectoryRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -27,7 +27,7 @@ namespace Baseline.Filesystem
         {
             BaseSourceAndDestinationDirectoryRequestValidator.ValidateAndThrowIfUnsuccessful(copyDirectoryRequest);
 
-            return GetAdapter(adapter)
+            return await GetAdapter(adapter)
                 .CopyDirectoryAsync(
                     copyDirectoryRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)), 
                     cancellationToken
@@ -37,14 +37,14 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public Task<AdapterAwareDirectoryRepresentation> CreateAsync(
+        public async Task<AdapterAwareDirectoryRepresentation> CreateAsync(
             CreateDirectoryRequest createDirectoryRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default)
         {
             BaseSingleDirectoryRequestValidator.ValidateAndThrowIfUnsuccessful(createDirectoryRequest);
 
-            return GetAdapter(adapter)
+            return await GetAdapter(adapter)
                 .CreateDirectoryAsync(
                     createDirectoryRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
@@ -54,14 +54,14 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public Task DeleteAsync(
+        public async Task DeleteAsync(
             DeleteDirectoryRequest deleteDirectoryRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default)
         {
             BaseSingleDirectoryRequestValidator.ValidateAndThrowIfUnsuccessful(deleteDirectoryRequest);
             
-            return GetAdapter(adapter)
+            await GetAdapter(adapter)
                 .DeleteDirectoryAsync(
                     deleteDirectoryRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)), 
                     cancellationToken
@@ -70,7 +70,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public Task<AdapterAwareDirectoryRepresentation> MoveAsync(
+        public async Task<AdapterAwareDirectoryRepresentation> MoveAsync(
             MoveDirectoryRequest moveDirectoryRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -78,7 +78,7 @@ namespace Baseline.Filesystem
         {
             BaseSourceAndDestinationDirectoryRequestValidator.ValidateAndThrowIfUnsuccessful(moveDirectoryRequest);
             
-            return GetAdapter(adapter)
+            return await GetAdapter(adapter)
                 .MoveDirectoryAsync(
                     moveDirectoryRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken

--- a/src/Baseline.Filesystem/DirectoryManager.cs
+++ b/src/Baseline.Filesystem/DirectoryManager.cs
@@ -33,7 +33,8 @@ namespace Baseline.Filesystem
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
-                .AsAdapterAwareRepresentationAsync(adapter);
+                .AsAdapterAwareRepresentationAsync(adapter)
+                .ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -50,7 +51,8 @@ namespace Baseline.Filesystem
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
-                .AsAdapterAwareRepresentationAsync(adapter);
+                .AsAdapterAwareRepresentationAsync(adapter)
+                .ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -66,7 +68,8 @@ namespace Baseline.Filesystem
                     deleteDirectoryRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)), 
                     cancellationToken
                 )
-                .WrapExternalExceptionsAsync(adapter);
+                .WrapExternalExceptionsAsync(adapter)
+                .ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -84,7 +87,8 @@ namespace Baseline.Filesystem
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
-                .AsAdapterAwareRepresentationAsync(adapter);
+                .AsAdapterAwareRepresentationAsync(adapter)
+                .ConfigureAwait(false);
         }
     }
 }

--- a/src/Baseline.Filesystem/FileManager.cs
+++ b/src/Baseline.Filesystem/FileManager.cs
@@ -19,7 +19,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public Task<AdapterAwareFileRepresentation> CopyAsync(
+        public async Task<AdapterAwareFileRepresentation> CopyAsync(
             CopyFileRequest copyFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -27,7 +27,7 @@ namespace Baseline.Filesystem
         {
             BaseSourceAndDestinationFileRequestValidator.ValidateAndThrowIfUnsuccessful(copyFileRequest);
             
-            return GetAdapter(adapter)
+            return await GetAdapter(adapter)
                 .CopyFileAsync(
                     copyFileRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
@@ -37,7 +37,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public Task DeleteAsync(
+        public async Task DeleteAsync(
             DeleteFileRequest deleteFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -45,7 +45,7 @@ namespace Baseline.Filesystem
         {
             BaseSingleFileRequestValidator.ValidateAndThrowIfUnsuccessful(deleteFileRequest);
 
-            return GetAdapter(adapter)
+            await GetAdapter(adapter)
                 .DeleteFileAsync(
                     deleteFileRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
@@ -54,7 +54,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public Task<bool> ExistsAsync(
+        public async Task<bool> ExistsAsync(
             FileExistsRequest fileExistsRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -62,7 +62,7 @@ namespace Baseline.Filesystem
         {
             BaseSingleFileRequestValidator.ValidateAndThrowIfUnsuccessful(fileExistsRequest);
 
-            return GetAdapter(adapter)
+            return await GetAdapter(adapter)
                 .FileExistsAsync(
                     fileExistsRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)), 
                     cancellationToken
@@ -71,7 +71,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public Task<AdapterAwareFileRepresentation> GetAsync(
+        public async Task<AdapterAwareFileRepresentation> GetAsync(
             GetFileRequest getFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -79,13 +79,30 @@ namespace Baseline.Filesystem
         {
             BaseSingleFileRequestValidator.ValidateAndThrowIfUnsuccessful(getFileRequest);
     
-            return GetAdapter(adapter)
+            return await GetAdapter(adapter)
                 .GetFileAsync(
                     getFileRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
                 .AsAdapterAwareRepresentationAsync(adapter);
+        }
+
+        /// <inheritdoc />
+        public async Task<GetFilePublicUrlResponse> GetPublicUrlAsync(
+            GetFilePublicUrlRequest getFilePublicUrlRequest,
+            string adapter = "default",
+            CancellationToken cancellationToken = default
+        )
+        {
+            BaseSingleFileRequestValidator.ValidateAndThrowIfUnsuccessful(getFilePublicUrlRequest);
+
+            return await GetAdapter(adapter)
+                .GetFilePublicUrlAsync(
+                    getFilePublicUrlRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)), 
+                    cancellationToken
+                )
+                .WrapExternalExceptionsAsync(adapter);
         }
 
         /// <inheritdoc />

--- a/src/Baseline.Filesystem/FileManager.cs
+++ b/src/Baseline.Filesystem/FileManager.cs
@@ -33,7 +33,8 @@ namespace Baseline.Filesystem
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
-                .AsAdapterAwareRepresentationAsync(adapter);
+                .AsAdapterAwareRepresentationAsync(adapter)
+                .ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -50,7 +51,8 @@ namespace Baseline.Filesystem
                     deleteFileRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
                 )
-                .WrapExternalExceptionsAsync(adapter);
+                .WrapExternalExceptionsAsync(adapter)
+                .ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -67,7 +69,8 @@ namespace Baseline.Filesystem
                     fileExistsRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)), 
                     cancellationToken
                 )
-                .WrapExternalExceptionsAsync(adapter);
+                .WrapExternalExceptionsAsync(adapter)
+                .ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -85,7 +88,8 @@ namespace Baseline.Filesystem
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
-                .AsAdapterAwareRepresentationAsync(adapter);
+                .AsAdapterAwareRepresentationAsync(adapter)
+                .ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -102,11 +106,12 @@ namespace Baseline.Filesystem
                     getFilePublicUrlRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)), 
                     cancellationToken
                 )
-                .WrapExternalExceptionsAsync(adapter);
+                .WrapExternalExceptionsAsync(adapter)
+                .ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public Task<AdapterAwareFileRepresentation> MoveAsync(
+        public async Task<AdapterAwareFileRepresentation> MoveAsync(
             MoveFileRequest moveFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -114,17 +119,18 @@ namespace Baseline.Filesystem
         {
             BaseSourceAndDestinationFileRequestValidator.ValidateAndThrowIfUnsuccessful(moveFileRequest);
 
-            return GetAdapter(adapter)
+            return await GetAdapter(adapter)
                 .MoveFileAsync(
                     moveFileRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
-                .AsAdapterAwareRepresentationAsync(adapter);
+                .AsAdapterAwareRepresentationAsync(adapter)
+                .ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public Task<string> ReadAsStringAsync(
+        public async Task<string> ReadAsStringAsync(
             ReadFileAsStringRequest readFileAsStringRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -132,16 +138,17 @@ namespace Baseline.Filesystem
         {
             BaseSingleFileRequestValidator.ValidateAndThrowIfUnsuccessful(readFileAsStringRequest);
 
-            return GetAdapter(adapter)
+            return await GetAdapter(adapter)
                 .ReadFileAsStringAsync(
                     readFileAsStringRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
                 )
-                .WrapExternalExceptionsAsync(adapter);
+                .WrapExternalExceptionsAsync(adapter)
+                .ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public Task<AdapterAwareFileRepresentation> TouchAsync(
+        public async Task<AdapterAwareFileRepresentation> TouchAsync(
             TouchFileRequest touchFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -149,17 +156,18 @@ namespace Baseline.Filesystem
         {
             BaseSingleFileRequestValidator.ValidateAndThrowIfUnsuccessful(touchFileRequest);
             
-            return GetAdapter(adapter)
+            return await GetAdapter(adapter)
                 .TouchFileAsync(
                     touchFileRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
-                .AsAdapterAwareRepresentationAsync(adapter);
+                .AsAdapterAwareRepresentationAsync(adapter)
+                .ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public Task WriteTextAsync(
+        public async Task WriteTextAsync(
             WriteTextToFileRequest writeTextToFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -167,12 +175,14 @@ namespace Baseline.Filesystem
         {
             WriteTextToFileRequestValidator.ValidateAndThrowIfUnsuccessful(writeTextToFileRequest);
 
-            return GetAdapter(adapter)
+            
+            await GetAdapter(adapter)
                 .WriteTextToFileAsync(
                     writeTextToFileRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
                 )
-                .WrapExternalExceptionsAsync(adapter);
+                .WrapExternalExceptionsAsync(adapter)
+                .ConfigureAwait(false);
         }
     }
 }

--- a/src/Baseline.Filesystem/FileManager.cs
+++ b/src/Baseline.Filesystem/FileManager.cs
@@ -99,7 +99,7 @@ namespace Baseline.Filesystem
             CancellationToken cancellationToken = default
         )
         {
-            BaseSingleFileRequestValidator.ValidateAndThrowIfUnsuccessful(getFilePublicUrlRequest);
+            GetFilePublicUrlRequestValidator.ValidateAndThrowIfUnsuccessful(getFilePublicUrlRequest);
 
             return await GetAdapter(adapter)
                 .GetFilePublicUrlAsync(

--- a/src/Baseline.Filesystem/Internal/Extensions/ExternalExceptionExtensions.cs
+++ b/src/Baseline.Filesystem/Internal/Extensions/ExternalExceptionExtensions.cs
@@ -60,7 +60,7 @@ namespace Baseline.Filesystem.Internal.Extensions
                 throw e.CreateAdapterException(adapterName);
             }
         }
-
+        
         /// <summary>
         /// Creates a <see cref="AdapterProviderOperationException"/> for a given exception and adapter name with a
         /// consistent message.

--- a/src/Baseline.Filesystem/Internal/Validators/Files/GetFilePublicUrlRequestValidator.cs
+++ b/src/Baseline.Filesystem/Internal/Validators/Files/GetFilePublicUrlRequestValidator.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Baseline.Filesystem.Internal.Validators.Files
+{
+    /// <summary>
+    /// Validators for the <see cref="GetFilePublicUrlRequest"/> class.
+    /// </summary>
+    internal class GetFilePublicUrlRequestValidator
+    {
+        /// <summary>
+        /// Validates the <see cref="GetFilePublicUrlRequest"/> request class and throws any applicable exceptions.
+        /// </summary>
+        /// <param name="request">The request to validate.</param>
+        public static void ValidateAndThrowIfUnsuccessful(GetFilePublicUrlRequest request)
+        {
+            BaseSingleFileRequestValidator.ValidateAndThrowIfUnsuccessful(request);
+
+            if (request.Expiry != null && request.Expiry <= DateTime.Now.AddSeconds(10))
+            {
+                throw new ArgumentException(
+                    "Expiry cannot be less than 10 seconds away from the current time.",
+                    nameof(request.Expiry)
+                );
+            }
+        }
+    }
+}

--- a/src/Baseline.Filesystem/Requests/File/GetFilePublicUrlRequest.cs
+++ b/src/Baseline.Filesystem/Requests/File/GetFilePublicUrlRequest.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Baseline.Filesystem
+{
+    /// <summary>
+    /// Request used to retrieve a public URL for a file.
+    /// </summary>
+    public class GetFilePublicUrlRequest : BaseSingleFileRequest<GetFilePublicUrlRequest>
+    {
+        /// <summary>
+        /// Gets or sets when the public URL should expire. This is not supported in all adapters, but will be defaulted
+        /// if you do not specify it.
+        /// </summary>
+        public DateTime? Expiry { get; set; }
+
+        /// <inheritdoc />
+        internal override GetFilePublicUrlRequest ShallowClone()
+        {
+            var cloned = base.ShallowClone();
+            cloned.Expiry = Expiry;
+            return cloned;
+        }
+    }
+}

--- a/src/Baseline.Filesystem/Responses/File/GetFilePublicUrlResponse.cs
+++ b/src/Baseline.Filesystem/Responses/File/GetFilePublicUrlResponse.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Baseline.Filesystem
+{
+    /// <summary>
+    /// Response returned from the GetPublicUrl method that retrieves a publicly accessible URL for the requested
+    /// file.
+    /// </summary>
+    public class GetFilePublicUrlResponse
+    {
+        /// <summary>
+        /// Gets or sets the public URL.
+        /// </summary>
+        public string Url { get; set; }
+        
+        /// <summary>
+        /// Gets or sets when the public URL expires, if applicable.
+        /// </summary>
+        public DateTime? Expiry { get; set; }
+    }
+}

--- a/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Files/GetPublicUrlTests.cs
+++ b/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Files/GetPublicUrlTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Files
+{
+    public class GetPublicUrlTests : BaseS3AdapterIntegrationTest
+    {
+        [Fact]
+        public async Task It_Throws_An_Exception_If_The_File_Does_Not_Exist()
+        {
+            Func<Task> act = async () => await FileManager.GetPublicUrlAsync(new GetFilePublicUrlRequest
+            {
+                FilePath = RandomFilePathRepresentation()
+            });
+            await act.Should().ThrowExactlyAsync<FileNotFoundException>();
+        }
+
+        [Fact]
+        public async Task It_Returns_The_Public_Url_If_The_File_Exists()
+        {
+            var path = RandomFilePathRepresentationWithPrefix("abc");
+
+            await CreateFileAndWriteTextAsync(path);
+
+            var response = await FileManager.GetPublicUrlAsync(new GetFilePublicUrlRequest
+            {
+                FilePath = path,
+                Expiry = DateTime.Today.AddDays(1)
+            });
+            response.Expiry.Should().Be(DateTime.Today.AddDays(1));
+            response.Url.Should().StartWith($"https://localhost:4566/{GeneratedBucketName}/{path.OriginalPath}");
+            response.Url.Should().Contain("X-Amz-Expires");
+            response.Url.Should().Contain("X-Amz-Algorithm");
+            response.Url.Should().Contain("X-Amz-SignedHeaders");
+        }
+
+        [Fact]
+        public async Task It_Defaults_The_Expiry_Date()
+        {
+            var path = RandomFilePathRepresentationWithPrefix("abc");
+
+            await CreateFileAndWriteTextAsync(path);
+
+            var response = await FileManager.GetPublicUrlAsync(new GetFilePublicUrlRequest
+            {
+                FilePath = path
+            });
+            response.Expiry.Should().Be(DateTime.Today.AddDays(1));
+        }
+
+        [Fact]
+        public async Task It_Retrieves_A_Public_Url_For_A_File_Under_A_Root_Path()
+        {
+            ReconfigureManagerInstances(true);
+            
+            var path = RandomFilePathRepresentationWithPrefix("abc");
+
+            await CreateFileAndWriteTextAsync(path);
+
+            var response = await FileManager.GetPublicUrlAsync(new GetFilePublicUrlRequest
+            {
+                FilePath = path,
+                Expiry = DateTime.Today.AddDays(1)
+            });
+            response.Expiry.Should().Be(DateTime.Today.AddDays(1));
+            response.Url.Should().StartWith($"https://localhost:4566/{GeneratedBucketName}/{CombinePathWithRootPath(path)}");
+            response.Url.Should().Contain("X-Amz-Expires");
+            response.Url.Should().Contain("X-Amz-Algorithm");
+            response.Url.Should().Contain("X-Amz-SignedHeaders");
+        }
+    }
+}

--- a/test/Baseline.Filesystem.Tests/FileManagerTests/GetPublicUrlAsyncTests.cs
+++ b/test/Baseline.Filesystem.Tests/FileManagerTests/GetPublicUrlAsyncTests.cs
@@ -44,6 +44,22 @@ namespace Baseline.Filesystem.Tests.FileManagerTests
             });
             await func.Should().ThrowExactlyAsync<PathIsADirectoryException>();
         }
+
+        [Fact]
+        public async Task It_Throws_An_Exception_If_The_Expiry_Date_Was_Not_Far_Enough_Away()
+        {
+            var path = "/users/Foo/bar/Destiny/XYZ/BARTINO.txt".AsBaselineFilesystemPath();
+            
+            Func<Task> func = async () => await FileManager.GetPublicUrlAsync(new GetFilePublicUrlRequest
+            {
+                FilePath = path,
+                Expiry = DateTime.Now
+            });
+            await func
+                .Should()
+                .ThrowExactlyAsync<ArgumentException>()
+                .WithMessage("Expiry cannot be less than 10 seconds away from the current time. (Parameter 'Expiry')");
+        }
         
         [Fact]
         public async Task It_Invokes_The_Matching_Adapters_Get_File_Method_And_Wraps_The_Response()

--- a/test/Baseline.Filesystem.Tests/FileManagerTests/GetPublicUrlAsyncTests.cs
+++ b/test/Baseline.Filesystem.Tests/FileManagerTests/GetPublicUrlAsyncTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Baseline.Filesystem.Tests.FileManagerTests
+{
+    public class GetPublicUrlAsyncTests : BaseManagerUsageTest
+    {
+        [Fact]
+        public async Task It_Throws_An_Exception_If_The_Requested_Adapter_Name_Is_Not_Registered()
+        {
+            Func<Task> func = async () => await FileManager.GetPublicUrlAsync(
+                new GetFilePublicUrlRequest { FilePath = "a".AsBaselineFilesystemPath() },
+                "foo"
+            );
+            await func.Should().ThrowAsync<AdapterNotFoundException>();
+        }
+
+        [Fact]
+        public async Task It_Throws_An_Exception_If_The_Request_Was_Null()
+        {
+            Func<Task> func = async () => await FileManager.GetPublicUrlAsync(null);
+            await func.Should().ThrowExactlyAsync<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async Task It_Throws_An_Exception_If_The_Path_For_The_Request_Was_Null()
+        {
+            Func<Task> func = async () => await FileManager.GetPublicUrlAsync(new GetFilePublicUrlRequest());
+            await func.Should().ThrowExactlyAsync<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async Task It_Throws_An_Exception_If_The_Path_Was_Obviously_Intended_As_A_Directory()
+        {
+            var path = "/users/Foo/bar/Destiny/XYZ/BARTINO/".AsBaselineFilesystemPath();
+            
+            Func<Task> func = async () => await FileManager.GetPublicUrlAsync(new GetFilePublicUrlRequest
+            {
+                FilePath = path
+            });
+            await func.Should().ThrowExactlyAsync<PathIsADirectoryException>();
+        }
+        
+        [Fact]
+        public async Task It_Invokes_The_Matching_Adapters_Get_File_Method_And_Wraps_The_Response()
+        {
+            Adapter
+                .Setup(x => x.GetFilePublicUrlAsync(It.IsAny<GetFilePublicUrlRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new GetFilePublicUrlResponse { Url = "https://www.google.com" })
+                .Verifiable();
+            
+            var response = await FileManager.GetPublicUrlAsync(new GetFilePublicUrlRequest
+            {
+                FilePath = "a".AsBaselineFilesystemPath()
+            });
+            response.Url.Should().Be("https://www.google.com");
+            
+            Adapter.VerifyAll();
+        }
+    }
+}

--- a/test/Baseline.Filesystem.Tests/Fixtures/SuccessfulOutcomeAdapter.cs
+++ b/test/Baseline.Filesystem.Tests/Fixtures/SuccessfulOutcomeAdapter.cs
@@ -73,5 +73,13 @@ namespace Baseline.Filesystem.Tests.Fixtures
         {
             return Task.CompletedTask;
         }
+
+        public Task<GetFilePublicUrlResponse> GetFilePublicUrlAsync(
+            GetFilePublicUrlRequest getFilePublicUrlRequest,
+            CancellationToken cancellationToken
+        )
+        {
+            return Task.FromResult(new GetFilePublicUrlResponse());
+        }
     }
 }


### PR DESCRIPTION
Added the aforementioned method to the file manager to allow public URLs to
be retrieved.

Implemented it within the S3 adapter.

Added a number of tests around it.

Stopped eliding async functions in the different manager classes.

Resolves #17