### PR TITLE
ISSUE-22 - Multi-target projects and update pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    
+    strategy:
+      matrix:
+        dotnet: [ '3.1.x', '5.0.x' ]
     services:
       localstack:
         image: localstack/localstack:latest
@@ -24,7 +26,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: ${{ matrix.dotnet }}
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,7 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ matrix.dotnet }}
-    - name: Restore dependencies
-      run: dotnet restore -f "${{ matrix.framework }}"
     - name: Build
-      run: dotnet build --no-restore -f "${{ matrix.framework }}"
+      run: dotnet build -f "${{ matrix.framework }}"
     - name: Test
       run: dotnet test --no-build --verbosity normal -f "${{ matrix.framework }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet: [ '3.1.x', '5.0.x' ]
+        include:
+          - dotnet: 3.1.x
+            framework: netcoreapp3.1
+          - dotnet: 5.0.x
+            framework: net5.0
     services:
       localstack:
         image: localstack/localstack:latest
@@ -28,8 +32,8 @@ jobs:
       with:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore -f "${{ matrix.framework }}"
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build --no-restore -f "${{ matrix.framework }}"
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal -f "${{ matrix.framework }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
             - name: Setup .NET
               uses: actions/setup-dotnet@v1
               with:
-                  dotnet-version: 3.1.x
+                  dotnet-version: 5.0.x
             - uses: olegtarasov/get-tag@v2.1
               id: tagName
               with:

--- a/src/Baseline.Filesystem.Adapters.S3/Baseline.Filesystem.Adapters.S3.csproj
+++ b/src/Baseline.Filesystem.Adapters.S3/Baseline.Filesystem.Adapters.S3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.0;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Baseline.Filesystem.Adapters.S3/Baseline.Filesystem.Adapters.S3.csproj
+++ b/src/Baseline.Filesystem.Adapters.S3/Baseline.Filesystem.Adapters.S3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Baseline.Filesystem.Adapters.S3/Baseline.Filesystem.Adapters.S3.csproj
+++ b/src/Baseline.Filesystem.Adapters.S3/Baseline.Filesystem.Adapters.S3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Baseline.Filesystem.DependencyInjection/Baseline.Filesystem.DependencyInjection.csproj
+++ b/src/Baseline.Filesystem.DependencyInjection/Baseline.Filesystem.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;netcoreapp3.0;net5.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Baseline.Filesystem.DependencyInjection/Baseline.Filesystem.DependencyInjection.csproj
+++ b/src/Baseline.Filesystem.DependencyInjection/Baseline.Filesystem.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;netcoreapp3.0;net5.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Baseline.Filesystem.DependencyInjection/Baseline.Filesystem.DependencyInjection.csproj
+++ b/src/Baseline.Filesystem.DependencyInjection/Baseline.Filesystem.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Baseline.Filesystem/Baseline.Filesystem.csproj
+++ b/src/Baseline.Filesystem/Baseline.Filesystem.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.0;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Baseline.Filesystem/Baseline.Filesystem.csproj
+++ b/src/Baseline.Filesystem/Baseline.Filesystem.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Baseline.Filesystem/Baseline.Filesystem.csproj
+++ b/src/Baseline.Filesystem/Baseline.Filesystem.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Baseline.Filesystem.Tests.Adapters.S3/Baseline.Filesystem.Tests.Adapters.S3.csproj
+++ b/test/Baseline.Filesystem.Tests.Adapters.S3/Baseline.Filesystem.Tests.Adapters.S3.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Baseline.Filesystem.Tests.DependencyInjection/Baseline.Filesystem.Tests.DependencyInjection.csproj
+++ b/test/Baseline.Filesystem.Tests.DependencyInjection/Baseline.Filesystem.Tests.DependencyInjection.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/test/Baseline.Filesystem.Tests.DependencyInjection/SimpleDependencyInjectionTests.cs
+++ b/test/Baseline.Filesystem.Tests.DependencyInjection/SimpleDependencyInjectionTests.cs
@@ -37,10 +37,10 @@ namespace Baseline.Filesystem.Tests.DependencyInjection
 
             // Assert.
             var adapterManager = serviceProvider.GetService<IAdapterManager>();
-            adapterManager!.Get("default").Adapter.Should().BeOfType<S3Adapter>();
+            adapterManager.Get("default").Adapter.Should().BeOfType<S3Adapter>();
 
             var fileManager = serviceProvider.GetService<IFileManager>();
-            var fileContents = await fileManager!.ReadAsStringAsync(
+            var fileContents = await fileManager.ReadAsStringAsync(
                 new ReadFileAsStringRequest
                 {
                     FilePath = filePath
@@ -76,10 +76,10 @@ namespace Baseline.Filesystem.Tests.DependencyInjection
 
             // Assert.
             var adapterManager = serviceProvider.GetService<IAdapterManager>();
-            adapterManager!.Get("default").Adapter.Should().BeOfType<S3Adapter>();
+            adapterManager.Get("default").Adapter.Should().BeOfType<S3Adapter>();
 
             var fileManager = serviceProvider.GetService<IFileManager>();
-            var fileContents = await fileManager!.ReadAsStringAsync(
+            var fileContents = await fileManager.ReadAsStringAsync(
                 new ReadFileAsStringRequest
                 {
                     FilePath = filePath
@@ -125,11 +125,11 @@ namespace Baseline.Filesystem.Tests.DependencyInjection
 
             // Assert.
             var adapterManager = serviceProvider.GetService<IAdapterManager>();
-            adapterManager!.Get("default").Adapter.Should().BeOfType<S3Adapter>();
-            adapterManager!.Get("second").Adapter.Should().BeOfType<S3Adapter>();
+            adapterManager.Get("default").Adapter.Should().BeOfType<S3Adapter>();
+            adapterManager.Get("second").Adapter.Should().BeOfType<S3Adapter>();
 
             var fileManager = serviceProvider.GetService<IFileManager>();
-            var fileContents = await fileManager!.ReadAsStringAsync(
+            var fileContents = await fileManager.ReadAsStringAsync(
                 new ReadFileAsStringRequest
                 {
                     FilePath = filePath
@@ -167,10 +167,10 @@ namespace Baseline.Filesystem.Tests.DependencyInjection
 
             // Assert.
             var adapterManager = serviceProvider.GetService<IAdapterManager>();
-            adapterManager!.Get("default").Adapter.Should().BeOfType<S3Adapter>();
+            adapterManager.Get("default").Adapter.Should().BeOfType<S3Adapter>();
 
             var fileManager = serviceProvider.GetService<IFileManager>();
-            var fileContents = await fileManager!.ReadAsStringAsync(
+            var fileContents = await fileManager.ReadAsStringAsync(
                 new ReadFileAsStringRequest
                 {
                     FilePath = filePath

--- a/test/Baseline.Filesystem.Tests/Baseline.Filesystem.Tests.csproj
+++ b/test/Baseline.Filesystem.Tests/Baseline.Filesystem.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Changed <TargetFramework> with a singular framework to be <TargetFrameworks> with multiple.

Updated the CI pipeline to run tests against both runtimes (netcoreapp3.1 and net5.0).

Updated the CI pipeline to run release builds in the .net5.0 runtime, but it will still be published as available for .netstandard2.1 and .netcoreapp3.1 as well.

Resolves #22 