### PR TITLE
#21 - Give each method a custom response model

### DIFF
--- a/src/Baseline.Filesystem.Adapters.S3/S3Adapter.File.cs
+++ b/src/Baseline.Filesystem.Adapters.S3/S3Adapter.File.cs
@@ -17,7 +17,7 @@ namespace Baseline.Filesystem
     public partial class S3Adapter
     {
         /// <inheritdoc />
-        public async Task<FileRepresentation> CopyFileAsync(
+        public async Task<CopyFileResponse> CopyFileAsync(
             CopyFileRequest copyFileRequest, 
             CancellationToken cancellationToken
         )
@@ -31,7 +31,10 @@ namespace Baseline.Filesystem
                 cancellationToken
             ).ConfigureAwait(false);
 
-            return new FileRepresentation {Path = copyFileRequest.DestinationFilePath};
+            return new CopyFileResponse
+            {
+                DestinationFile = new FileRepresentation {Path = copyFileRequest.DestinationFilePath}
+            };
         }
 
         /// <inheritdoc />
@@ -42,12 +45,16 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public async Task<bool> FileExistsAsync(
+        public async Task<FileExistsResponse> FileExistsAsync(
             FileExistsRequest fileExistsRequest,
             CancellationToken cancellationToken
         )
         {
-            return await FileExistsInternalAsync(fileExistsRequest.FilePath, cancellationToken).ConfigureAwait(false);
+            return new FileExistsResponse
+            {
+                FileExists = await FileExistsInternalAsync(fileExistsRequest.FilePath, cancellationToken)
+                    .ConfigureAwait(false)
+            };
         }
 
         /// <inheritdoc />

--- a/src/Baseline.Filesystem.Adapters.S3/S3Adapter.File.cs
+++ b/src/Baseline.Filesystem.Adapters.S3/S3Adapter.File.cs
@@ -38,10 +38,15 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public async Task DeleteFileAsync(DeleteFileRequest deleteFileRequest, CancellationToken cancellationToken)
+        public async Task<DeleteFileResponse> DeleteFileAsync(
+            DeleteFileRequest deleteFileRequest, 
+            CancellationToken cancellationToken
+        )
         {
             await EnsureFileExistsAsync(deleteFileRequest.FilePath, cancellationToken).ConfigureAwait(false);
             await DeleteFileInternalAsync(deleteFileRequest.FilePath, cancellationToken).ConfigureAwait(false);
+
+            return new DeleteFileResponse();
         }
 
         /// <inheritdoc />
@@ -58,13 +63,15 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public async Task<FileRepresentation> GetFileAsync(
+        public async Task<GetFileResponse> GetFileAsync(
             GetFileRequest getFileRequest, 
             CancellationToken cancellationToken
         )
         {
             var fileExists = await FileExistsInternalAsync(getFileRequest.FilePath, cancellationToken).ConfigureAwait(false);
-            return fileExists ? new FileRepresentation {Path = getFileRequest.FilePath} : null;
+            return fileExists 
+                ? new GetFileResponse { File = new FileRepresentation {Path = getFileRequest.FilePath} } 
+                : null;
         }
         
         /// <inheritdoc />
@@ -90,7 +97,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public async Task<FileRepresentation> MoveFileAsync(
+        public async Task<MoveFileResponse> MoveFileAsync(
             MoveFileRequest moveFileRequest, 
             CancellationToken cancellationToken
         )
@@ -106,11 +113,14 @@ namespace Baseline.Filesystem
 
             await DeleteFileInternalAsync(moveFileRequest.SourceFilePath, cancellationToken).ConfigureAwait(false);
 
-            return new FileRepresentation { Path = moveFileRequest.DestinationFilePath };
+            return new MoveFileResponse
+            {
+                DestinationFile = new FileRepresentation {Path = moveFileRequest.DestinationFilePath}
+            };
         }
 
         /// <inheritdoc />
-        public async Task<string> ReadFileAsStringAsync(
+        public async Task<ReadFileAsStringResponse> ReadFileAsStringAsync(
             ReadFileAsStringRequest readFileAsStringRequest,
             CancellationToken cancellationToken
         )
@@ -123,18 +133,25 @@ namespace Baseline.Filesystem
                 cancellationToken
             ).ConfigureAwait(false);
 
-            return await new StreamReader(file.ResponseStream).ReadToEndAsync().ConfigureAwait(false);
+            return new ReadFileAsStringResponse
+            {
+                FileContents = await new StreamReader(file.ResponseStream).ReadToEndAsync().ConfigureAwait(false)
+            };
         }
 
         /// <inheritdoc />
-        public async Task<FileRepresentation> TouchFileAsync(
+        public async Task<TouchFileResponse> TouchFileAsync(
             TouchFileRequest touchFileRequest,
             CancellationToken cancellationToken
         )
         {
             await EnsureFileDoesNotExistAsync(touchFileRequest.FilePath, cancellationToken).ConfigureAwait(false);
             await TouchFileInternalAsync(touchFileRequest.FilePath, cancellationToken).ConfigureAwait(false);
-            return new FileRepresentation { Path = touchFileRequest.FilePath };
+            
+            return new TouchFileResponse
+            {
+                File = new FileRepresentation {Path = touchFileRequest.FilePath}
+            };
         }
 
         /// <inheritdoc />
@@ -159,7 +176,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public async Task WriteTextToFileAsync(
+        public async Task<WriteTextToFileResponse> WriteTextToFileAsync(
             WriteTextToFileRequest writeTextToFileRequest,
             CancellationToken cancellationToken
         )
@@ -174,6 +191,8 @@ namespace Baseline.Filesystem
                 },
                 cancellationToken
             ).ConfigureAwait(false);
+
+            return new WriteTextToFileResponse();
         }
 
         /// <summary>

--- a/src/Baseline.Filesystem/Contracts/IAdapter.cs
+++ b/src/Baseline.Filesystem/Contracts/IAdapter.cs
@@ -25,8 +25,7 @@ namespace Baseline.Filesystem
         /// </summary>
         /// <param name="copyFileRequest">The request containing information about the file to copy.</param>
         /// <param name="cancellationToken">The cancellation token used to cancel any asynchronous tasks.</param>
-        /// <returns>The information about the file that was created (the destination file).</returns>
-        Task<FileRepresentation> CopyFileAsync(CopyFileRequest copyFileRequest, CancellationToken cancellationToken);
+        Task<CopyFileResponse> CopyFileAsync(CopyFileRequest copyFileRequest, CancellationToken cancellationToken);
 
         /// <summary>
         /// Creates a directory in an adapter's data store.
@@ -61,7 +60,7 @@ namespace Baseline.Filesystem
         /// <param name="fileExistsRequest">The request containing information about the file to check.</param>
         /// <param name="cancellationToken">The cancellation token used to cancel any asynchronous tasks.</param>
         /// <returns>Whether or not the file defined in the request exists.</returns>
-        Task<bool> FileExistsAsync(FileExistsRequest fileExistsRequest, CancellationToken cancellationToken);
+        Task<FileExistsResponse> FileExistsAsync(FileExistsRequest fileExistsRequest, CancellationToken cancellationToken);
         
         /// <summary>
         /// Gets a file's information (i.e. the name, path, extension, size etc) from the adapter's data store.

--- a/src/Baseline.Filesystem/Contracts/IAdapter.cs
+++ b/src/Baseline.Filesystem/Contracts/IAdapter.cs
@@ -15,7 +15,7 @@ namespace Baseline.Filesystem
         /// <param name="copyDirectoryRequest">The request containing information about the directory to copy.</param>
         /// <param name="cancellationToken">The cancellation token used to cancel any asynchronous tasks.</param>
         /// <returns>The information about the directory that was created (the destination directory).</returns>
-        Task<DirectoryRepresentation> CopyDirectoryAsync(
+        Task<CopyDirectoryResponse> CopyDirectoryAsync(
             CopyDirectoryRequest copyDirectoryRequest,
             CancellationToken cancellationToken
         );
@@ -35,7 +35,7 @@ namespace Baseline.Filesystem
         /// </param>
         /// <param name="cancellationToken">The cancellation token used to cancel any asynchronous tasks.</param>
         /// <returns>The information about the directory that was created (the destination directory).</returns>
-        Task<DirectoryRepresentation> CreateDirectoryAsync(
+        Task<CreateDirectoryResponse> CreateDirectoryAsync(
             CreateDirectoryRequest createDirectoryRequest,
             CancellationToken cancellationToken
         );
@@ -45,14 +45,17 @@ namespace Baseline.Filesystem
         /// </summary>
         /// <param name="deleteDirectoryRequest">The request containing information about the directory to delete.</param>
         /// <param name="cancellationToken">The cancellation token used to cancel any asynchronous tasks.</param>
-        Task DeleteDirectoryAsync(DeleteDirectoryRequest deleteDirectoryRequest, CancellationToken cancellationToken);
+        Task<DeleteDirectoryResponse> DeleteDirectoryAsync(
+            DeleteDirectoryRequest deleteDirectoryRequest, 
+            CancellationToken cancellationToken
+        );
         
         /// <summary>
         /// Deletes a file from the adapter's data store.
         /// </summary>
         /// <param name="deleteFileRequest">The request containing information about the file to delete.</param>
         /// <param name="cancellationToken">The cancellation token used to cancel any asynchronous tasks.</param>
-        Task DeleteFileAsync(DeleteFileRequest deleteFileRequest, CancellationToken cancellationToken);
+        Task<DeleteFileResponse> DeleteFileAsync(DeleteFileRequest deleteFileRequest, CancellationToken cancellationToken);
         
         /// <summary>
         /// Checks whether a file exists or not in the adapter's data store.
@@ -68,7 +71,7 @@ namespace Baseline.Filesystem
         /// <param name="getFileRequest">The request containing information about the file to retrieve.</param>
         /// <param name="cancellationToken">The cancellation token used to cancel any asynchronous tasks.</param>
         /// <returns>The information about the requested file.</returns>
-        Task<FileRepresentation> GetFileAsync(GetFileRequest getFileRequest, CancellationToken cancellationToken);
+        Task<GetFileResponse> GetFileAsync(GetFileRequest getFileRequest, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves a public URL for a file from the adapter's data store.
@@ -101,7 +104,7 @@ namespace Baseline.Filesystem
         /// <param name="moveDirectoryRequest">The request containing information about the directory to move.</param>
         /// <param name="cancellationToken">The cancellation token used to cancel any asynchronous tasks.</param>
         /// <returns>The information about the directory that was created (the destination directory).</returns>
-        Task<DirectoryRepresentation> MoveDirectoryAsync(
+        Task<MoveDirectoryResponse> MoveDirectoryAsync(
             MoveDirectoryRequest moveDirectoryRequest,
             CancellationToken cancellationToken
         );
@@ -114,7 +117,7 @@ namespace Baseline.Filesystem
         /// </param>
         /// <param name="cancellationToken">The cancellation token used to cancel any asynchronous tasks.</param>
         /// <returns>The information about the destination file of the move request.</returns>
-        Task<FileRepresentation> MoveFileAsync(MoveFileRequest moveFileRequest, CancellationToken cancellationToken);
+        Task<MoveFileResponse> MoveFileAsync(MoveFileRequest moveFileRequest, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves a file from the adapter's data store and reads its contents as a string.
@@ -124,7 +127,7 @@ namespace Baseline.Filesystem
         /// </param>
         /// <param name="cancellationToken">The cancellation token used to cancel any asynchronous tasks.</param>
         /// <returns>The file's contents.</returns>
-        Task<string> ReadFileAsStringAsync(
+        Task<ReadFileAsStringResponse> ReadFileAsStringAsync(
             ReadFileAsStringRequest readFileAsStringRequest,
             CancellationToken cancellationToken
         );
@@ -135,7 +138,7 @@ namespace Baseline.Filesystem
         /// <param name="touchFileRequest">The request containing information about the file to touch.</param>
         /// <param name="cancellationToken">The cancellation token used to cancel any asynchronous tasks.</param>
         /// <returns>The information about the file that was created.</returns>
-        Task<FileRepresentation> TouchFileAsync(TouchFileRequest touchFileRequest, CancellationToken cancellationToken);
+        Task<TouchFileResponse> TouchFileAsync(TouchFileRequest touchFileRequest, CancellationToken cancellationToken);
 
         /// <summary>
         /// Writes a stream to a file within the adapter's data store, creating it if it doesn't exist or overwriting it
@@ -157,6 +160,9 @@ namespace Baseline.Filesystem
         /// The request containing information about what to write and to where.
         /// </param>
         /// <param name="cancellationToken">The cancellation token used to cancel any asynchronous tasks.</param>
-        Task WriteTextToFileAsync(WriteTextToFileRequest writeTextToFileRequest, CancellationToken cancellationToken);
+        Task<WriteTextToFileResponse> WriteTextToFileAsync(
+            WriteTextToFileRequest writeTextToFileRequest, 
+            CancellationToken cancellationToken
+        );
     }
 }

--- a/src/Baseline.Filesystem/Contracts/IDirectoryManager.cs
+++ b/src/Baseline.Filesystem/Contracts/IDirectoryManager.cs
@@ -29,7 +29,7 @@ namespace Baseline.Filesystem
         /// <exception cref="PathIsNotObviouslyADirectoryException" />
         /// <exception cref="DirectoryNotFoundException" />
         /// <exception cref="DirectoryAlreadyExistsException" />
-        Task<DirectoryRepresentation> CopyAsync(
+        Task<CopyDirectoryResponse> CopyAsync(
             CopyDirectoryRequest copyDirectoryRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -52,7 +52,7 @@ namespace Baseline.Filesystem
         /// <exception cref="PathIsRelativeException" />
         /// <exception cref="PathIsNotObviouslyADirectoryException" />
         /// <exception cref="DirectoryAlreadyExistsException" />
-        Task<DirectoryRepresentation> CreateAsync(
+        Task<CreateDirectoryResponse> CreateAsync(
             CreateDirectoryRequest createDirectoryRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -76,7 +76,7 @@ namespace Baseline.Filesystem
         /// <exception cref="PathIsRelativeException" />
         /// <exception cref="PathIsNotObviouslyADirectoryException" />
         /// <exception cref="DirectoryNotFoundException" />
-        Task DeleteAsync(
+        Task<DeleteDirectoryResponse> DeleteAsync(
             DeleteDirectoryRequest deleteDirectoryRequest, 
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -126,7 +126,7 @@ namespace Baseline.Filesystem
         /// <exception cref="PathIsNotObviouslyADirectoryException" />
         /// <exception cref="DirectoryNotFoundException" />
         /// <exception cref="DirectoryAlreadyExistsException" />
-        Task<DirectoryRepresentation> MoveAsync(
+        Task<MoveDirectoryResponse> MoveAsync(
             MoveDirectoryRequest moveDirectoryRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default

--- a/src/Baseline.Filesystem/Contracts/IFileManager.cs
+++ b/src/Baseline.Filesystem/Contracts/IFileManager.cs
@@ -50,7 +50,7 @@ namespace Baseline.Filesystem
         /// <exception cref="PathIsRelativeException" />
         /// <exception cref="PathIsADirectoryException" />
         /// <exception cref="FileNotFoundException" />
-        Task DeleteAsync(
+        Task<DeleteFileResponse> DeleteAsync(
             DeleteFileRequest deleteFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -98,7 +98,7 @@ namespace Baseline.Filesystem
         /// <exception cref="PathIsRelativeException" />
         /// <exception cref="PathIsADirectoryException" />
         /// <exception cref="FileNotFoundException" />
-        Task<FileRepresentation> GetAsync(
+        Task<GetFileResponse> GetAsync(
             GetFileRequest getFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -138,7 +138,7 @@ namespace Baseline.Filesystem
         /// <exception cref="PathIsADirectoryException" />
         /// <exception cref="FileNotFoundException" />
         /// <exception cref="FileAlreadyExistsException" />
-        Task<FileRepresentation> MoveAsync(
+        Task<MoveFileResponse> MoveAsync(
             MoveFileRequest moveFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -163,7 +163,7 @@ namespace Baseline.Filesystem
         /// <exception cref="PathIsRelativeException" />
         /// <exception cref="PathIsADirectoryException" />
         /// <exception cref="FileNotFoundException" />
-        Task<string> ReadAsStringAsync(
+        Task<ReadFileAsStringResponse> ReadAsStringAsync(
             ReadFileAsStringRequest readFileAsStringRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -188,7 +188,7 @@ namespace Baseline.Filesystem
         /// <exception cref="PathIsRelativeException" />
         /// <exception cref="PathIsADirectoryException" />
         /// <exception cref="FileAlreadyExistsException" />
-        Task<FileRepresentation> TouchAsync(
+        Task<TouchFileResponse> TouchAsync(
             TouchFileRequest touchFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -211,7 +211,7 @@ namespace Baseline.Filesystem
         /// <exception cref="PathContainsInvalidCharacterException" />
         /// <exception cref="PathIsRelativeException" />
         /// <exception cref="PathIsADirectoryException" />
-        Task WriteTextAsync(
+        Task<WriteTextToFileResponse> WriteTextAsync(
             WriteTextToFileRequest writeTextToFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default

--- a/src/Baseline.Filesystem/Contracts/IFileManager.cs
+++ b/src/Baseline.Filesystem/Contracts/IFileManager.cs
@@ -19,7 +19,6 @@ namespace Baseline.Filesystem
         /// <param name="cancellationToken">
         /// The cancellation token used to cancel asynchronous requests if required.
         /// </param>
-        /// <returns>The file representation of the newly copied file.</returns>
         /// <exception cref="ArgumentNullException" />
         /// <exception cref="AdapterNotFoundException" />
         /// <exception cref="AdapterProviderOperationException" />
@@ -29,7 +28,7 @@ namespace Baseline.Filesystem
         /// <exception cref="PathIsADirectoryException" />
         /// <exception cref="FileNotFoundException" />
         /// <exception cref="FileAlreadyExistsException" />
-        Task<FileRepresentation> CopyAsync(
+        Task<CopyFileResponse> CopyAsync(
             CopyFileRequest copyFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -75,7 +74,7 @@ namespace Baseline.Filesystem
         /// <exception cref="PathContainsInvalidCharacterException" />
         /// <exception cref="PathIsRelativeException" />
         /// <exception cref="PathIsADirectoryException" />
-        Task<bool> ExistsAsync(
+        Task<FileExistsResponse> ExistsAsync(
             FileExistsRequest fileExistsRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default

--- a/src/Baseline.Filesystem/DirectoryManager.cs
+++ b/src/Baseline.Filesystem/DirectoryManager.cs
@@ -20,7 +20,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public async Task<DirectoryRepresentation> CopyAsync(
+        public async Task<CopyDirectoryResponse> CopyAsync(
             CopyDirectoryRequest copyDirectoryRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -38,7 +38,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public async Task<DirectoryRepresentation> CreateAsync(
+        public async Task<CreateDirectoryResponse> CreateAsync(
             CreateDirectoryRequest createDirectoryRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -56,7 +56,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public async Task DeleteAsync(
+        public async Task<DeleteDirectoryResponse> DeleteAsync(
             DeleteDirectoryRequest deleteDirectoryRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -64,7 +64,7 @@ namespace Baseline.Filesystem
         {
             BaseSingleDirectoryRequestValidator.ValidateAndThrowIfUnsuccessful(deleteDirectoryRequest);
             
-            await GetAdapter(adapter)
+            return await GetAdapter(adapter)
                 .DeleteDirectoryAsync(
                     deleteDirectoryRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)), 
                     cancellationToken
@@ -102,7 +102,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public async Task<DirectoryRepresentation> MoveAsync(
+        public async Task<MoveDirectoryResponse> MoveAsync(
             MoveDirectoryRequest moveDirectoryRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default

--- a/src/Baseline.Filesystem/FileManager.cs
+++ b/src/Baseline.Filesystem/FileManager.cs
@@ -19,7 +19,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public async Task<FileRepresentation> CopyAsync(
+        public async Task<CopyFileResponse> CopyAsync(
             CopyFileRequest copyFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -55,7 +55,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public async Task<bool> ExistsAsync(
+        public async Task<FileExistsResponse> ExistsAsync(
             FileExistsRequest fileExistsRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default

--- a/src/Baseline.Filesystem/FileManager.cs
+++ b/src/Baseline.Filesystem/FileManager.cs
@@ -37,7 +37,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public async Task DeleteAsync(
+        public async Task<DeleteFileResponse> DeleteAsync(
             DeleteFileRequest deleteFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -45,7 +45,7 @@ namespace Baseline.Filesystem
         {
             BaseSingleFileRequestValidator.ValidateAndThrowIfUnsuccessful(deleteFileRequest);
 
-            await GetAdapter(adapter)
+            return await GetAdapter(adapter)
                 .DeleteFileAsync(
                     deleteFileRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
@@ -73,7 +73,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public async Task<FileRepresentation> GetAsync(
+        public async Task<GetFileResponse> GetAsync(
             GetFileRequest getFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -109,7 +109,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public async Task<FileRepresentation> MoveAsync(
+        public async Task<MoveFileResponse> MoveAsync(
             MoveFileRequest moveFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -127,7 +127,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public async Task<string> ReadAsStringAsync(
+        public async Task<ReadFileAsStringResponse> ReadAsStringAsync(
             ReadFileAsStringRequest readFileAsStringRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -145,7 +145,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public async Task<FileRepresentation> TouchAsync(
+        public async Task<TouchFileResponse> TouchAsync(
             TouchFileRequest touchFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -181,7 +181,7 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public async Task WriteTextAsync(
+        public async Task<WriteTextToFileResponse> WriteTextAsync(
             WriteTextToFileRequest writeTextToFileRequest,
             string adapter = "default",
             CancellationToken cancellationToken = default
@@ -189,7 +189,7 @@ namespace Baseline.Filesystem
         {
             WriteTextToFileRequestValidator.ValidateAndThrowIfUnsuccessful(writeTextToFileRequest);
             
-            await GetAdapter(adapter)
+            return await GetAdapter(adapter)
                 .WriteTextToFileAsync(
                     writeTextToFileRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken

--- a/src/Baseline.Filesystem/Representations/PathRepresentation.cs
+++ b/src/Baseline.Filesystem/Representations/PathRepresentation.cs
@@ -13,7 +13,7 @@ namespace Baseline.Filesystem
         /// representation. This is stored as a function to stop the unneccessary and complex lookups when creating
         /// what is otherwise a light object.
         /// <example>
-        /// For the path a/b/c/d/e/f/g/.keep, <see cref="PathTree"/> would return the following:
+        /// For the path a/b/c/d/e/f/g/.keep, <see cref="GetPathTree"/> would return the following:
         /// <list type="bullet">
         ///     <item>
         ///         <description>a/</description>
@@ -70,7 +70,7 @@ namespace Baseline.Filesystem
         /// Combines the current path representation with a base path representation, wherein the base path
         /// representation is set first, and the current path after.
         /// </summary>
-        /// <param name="@base">The base path to combine with the current path.</param>
+        /// <param name="base">The base path to combine with the current path.</param>
         /// <returns>The newly combined path.</returns>
         internal PathRepresentation CombineWithBase(PathRepresentation @base)
         {

--- a/src/Baseline.Filesystem/Responses/Directory/CopyDirectoryResponse.cs
+++ b/src/Baseline.Filesystem/Responses/Directory/CopyDirectoryResponse.cs
@@ -1,0 +1,13 @@
+namespace Baseline.Filesystem
+{
+    /// <summary>
+    /// Response returned from the DirectoryManager.Copy method.
+    /// </summary>
+    public class CopyDirectoryResponse
+    {
+        /// <summary>
+        /// Gets or sets the representation of the directory that the source directory was copied to.
+        /// </summary>
+        public DirectoryRepresentation DestinationDirectory { get; set; }
+    }
+}

--- a/src/Baseline.Filesystem/Responses/Directory/CreateDirectoryResponse.cs
+++ b/src/Baseline.Filesystem/Responses/Directory/CreateDirectoryResponse.cs
@@ -1,0 +1,13 @@
+namespace Baseline.Filesystem
+{
+    /// <summary>
+    /// Response returned from the DirectoryManager.Create method.
+    /// </summary>
+    public class CreateDirectoryResponse
+    {
+        /// <summary>
+        /// Gets or sets the representation of the directory that was created as part of the request.
+        /// </summary>
+        public DirectoryRepresentation Directory { get; set; }
+    }
+}

--- a/src/Baseline.Filesystem/Responses/Directory/DeleteDirectoryResponse.cs
+++ b/src/Baseline.Filesystem/Responses/Directory/DeleteDirectoryResponse.cs
@@ -1,0 +1,10 @@
+namespace Baseline.Filesystem
+{
+    /// <summary>
+    /// Response returned from the DirectoryManager.Delete method. Empty for now for future proofing and to prevent
+    /// any unnecessary breaking changes.
+    /// </summary>
+    public class DeleteDirectoryResponse
+    {
+    }
+}

--- a/src/Baseline.Filesystem/Responses/Directory/MoveDirectoryResponse.cs
+++ b/src/Baseline.Filesystem/Responses/Directory/MoveDirectoryResponse.cs
@@ -1,0 +1,13 @@
+namespace Baseline.Filesystem
+{
+    /// <summary>
+    /// Response returned from the DirectoryManager.Move method.
+    /// </summary>
+    public class MoveDirectoryResponse
+    {
+        /// <summary>
+        /// Gets or sets the destination directory representation, i.e. where the source directory was moved to.
+        /// </summary>
+        public DirectoryRepresentation DestinationDirectory { get; set; }
+    }
+}

--- a/src/Baseline.Filesystem/Responses/File/CopyFileResponse.cs
+++ b/src/Baseline.Filesystem/Responses/File/CopyFileResponse.cs
@@ -1,0 +1,13 @@
+namespace Baseline.Filesystem
+{
+    /// <summary>
+    /// Response representing the outcome of action to copy a file.
+    /// </summary>
+    public class CopyFileResponse
+    {
+        /// <summary>
+        /// Gets or sets the file information of the destination file.
+        /// </summary>
+        public FileRepresentation DestinationFile { get; set; }
+    }
+}

--- a/src/Baseline.Filesystem/Responses/File/DeleteFileResponse.cs
+++ b/src/Baseline.Filesystem/Responses/File/DeleteFileResponse.cs
@@ -1,0 +1,9 @@
+namespace Baseline.Filesystem
+{
+    /// <summary>
+    /// Response returned from the FileManager.Delete method. Currently empty, but present to make future proofing easier.
+    /// </summary>
+    public class DeleteFileResponse
+    {
+    }
+}

--- a/src/Baseline.Filesystem/Responses/File/FileExistsResponse.cs
+++ b/src/Baseline.Filesystem/Responses/File/FileExistsResponse.cs
@@ -1,7 +1,7 @@
 namespace Baseline.Filesystem
 {
     /// <summary>
-    /// Response returned from the FileExists method.
+    /// Response returned from the FileManager.Exists method.
     /// </summary>
     public class FileExistsResponse
     {

--- a/src/Baseline.Filesystem/Responses/File/FileExistsResponse.cs
+++ b/src/Baseline.Filesystem/Responses/File/FileExistsResponse.cs
@@ -1,0 +1,13 @@
+namespace Baseline.Filesystem
+{
+    /// <summary>
+    /// Response returned from the FileExists method.
+    /// </summary>
+    public class FileExistsResponse
+    {
+        /// <summary>
+        /// Gets or sets whether the file does exist or not.
+        /// </summary>
+        public bool FileExists { get; set; }
+    }
+}

--- a/src/Baseline.Filesystem/Responses/File/GetFileResponse.cs
+++ b/src/Baseline.Filesystem/Responses/File/GetFileResponse.cs
@@ -1,0 +1,13 @@
+namespace Baseline.Filesystem
+{
+    /// <summary>
+    /// Response returned from the FileManager.GetFile method.
+    /// </summary>
+    public class GetFileResponse
+    {
+        /// <summary>
+        /// Gets or sets the file representation that was requested.
+        /// </summary>
+        public FileRepresentation File { get; set; }
+    }
+}

--- a/src/Baseline.Filesystem/Responses/File/MoveFileResponse.cs
+++ b/src/Baseline.Filesystem/Responses/File/MoveFileResponse.cs
@@ -1,0 +1,13 @@
+namespace Baseline.Filesystem
+{
+    /// <summary>
+    /// Response returned from the FileManager.Move method.
+    /// </summary>
+    public class MoveFileResponse
+    {
+        /// <summary>
+        /// Gets or sets the representation of the file in its DESTINATION.
+        /// </summary>
+        public FileRepresentation DestinationFile { get; set; }
+    }
+}

--- a/src/Baseline.Filesystem/Responses/File/ReadFileAsStringResponse.cs
+++ b/src/Baseline.Filesystem/Responses/File/ReadFileAsStringResponse.cs
@@ -1,0 +1,13 @@
+namespace Baseline.Filesystem
+{
+    /// <summary>
+    /// Response returned from the FileManager.ReadAsString method.
+    /// </summary>
+    public class ReadFileAsStringResponse
+    {
+        /// <summary>
+        /// Gets or sets the file's contents in string format.
+        /// </summary>
+        public string FileContents { get; set; }
+    }
+}

--- a/src/Baseline.Filesystem/Responses/File/TouchFileResponse.cs
+++ b/src/Baseline.Filesystem/Responses/File/TouchFileResponse.cs
@@ -1,0 +1,13 @@
+namespace Baseline.Filesystem
+{
+    /// <summary>
+    /// A response returned from the FileManager.Touch method.
+    /// </summary>
+    public class TouchFileResponse
+    {
+        /// <summary>
+        /// Gets or sets the representation of the file that is created.
+        /// </summary>
+        public FileRepresentation File { get; set; }
+    }
+}

--- a/src/Baseline.Filesystem/Responses/File/WriteTextToFileResponse.cs
+++ b/src/Baseline.Filesystem/Responses/File/WriteTextToFileResponse.cs
@@ -1,0 +1,10 @@
+namespace Baseline.Filesystem
+{
+    /// <summary>
+    /// Response returned from the FileManager.WriteText method. Currently unused, but present to future proof and
+    /// prevent any breaking changes.
+    /// </summary>
+    public class WriteTextToFileResponse
+    {
+    }
+}

--- a/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Directories/CreateDirectoryTests.cs
+++ b/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Directories/CreateDirectoryTests.cs
@@ -37,7 +37,7 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Directories
             
             // Assert.
             await ExpectDirectoryToExistAsync(directory);
-            response.Path.Should().BeEquivalentTo(directory);
+            response.Directory.Path.Should().BeEquivalentTo(directory);
         }
 
         [Fact]
@@ -53,7 +53,11 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Directories
             
             // Assert.
             await ExpectDirectoryToExistAsync(directory);
-            response.Path.Should().BeEquivalentTo(CombinedPathWithRootPathForAssertion(directory), x => x.Excluding(y => y.GetPathTree));
+            response
+                .Directory
+                .Path
+                .Should()
+                .BeEquivalentTo(CombinedPathWithRootPathForAssertion(directory), x => x.Excluding(y => y.GetPathTree));
         }
     }
 }

--- a/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Files/FileExistsTests.cs
+++ b/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Files/FileExistsTests.cs
@@ -23,7 +23,7 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Files
             );
             
             // Assert.
-            response.Should().BeTrue();
+            response.FileExists.Should().BeTrue();
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Files
             );
             
             // Assert.
-            response.Should().BeFalse();
+            response.FileExists.Should().BeFalse();
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Files
             );
             
             // Assert.
-            response.Should().BeTrue();
+            response.FileExists.Should().BeTrue();
         }
     }
 }

--- a/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Files/GetFileTests.cs
+++ b/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Files/GetFileTests.cs
@@ -29,7 +29,7 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Files
             
             // Assert.
             var response = await FileManager.GetAsync(new GetFileRequest {FilePath = path});
-            response.Path.Should().Be(path);
+            response.File.Path.Should().Be(path);
         }
 
         [Fact]
@@ -45,7 +45,11 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Files
             
             // Assert.
             var response = await FileManager.GetAsync(new GetFileRequest {FilePath = path});
-            response.Path.Should().BeEquivalentTo(CombinedPathWithRootPathForAssertion(path), x => x.Excluding(y => y.GetPathTree));
+            response
+                .File
+                .Path
+                .Should()
+                .BeEquivalentTo(CombinedPathWithRootPathForAssertion(path), x => x.Excluding(y => y.GetPathTree));
         }
     }
 }

--- a/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Files/MoveFileTests.cs
+++ b/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Files/MoveFileTests.cs
@@ -61,7 +61,7 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Files
             });
             
             // Assert.
-            fileContents.Should().Be("abc");
+            fileContents.FileContents.Should().Be("abc");
         }
 
         [Fact]

--- a/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Files/ReadFileAsStringTests.cs
+++ b/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Files/ReadFileAsStringTests.cs
@@ -39,7 +39,7 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Files
             var fileContents = await FileManager.ReadAsStringAsync(new ReadFileAsStringRequest { FilePath = path });
             
             // Assert.
-            fileContents.Should().Be("you should check these contents");
+            fileContents.FileContents.Should().Be("you should check these contents");
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Files
             var fileContents = await FileManager.ReadAsStringAsync(new ReadFileAsStringRequest { FilePath = path });
             
             // Assert.
-            fileContents.Should().Be("you should check these contents");
+            fileContents.FileContents.Should().Be("you should check these contents");
         }
     }
 }

--- a/test/Baseline.Filesystem.Tests.DependencyInjection/SimpleDependencyInjectionTests.cs
+++ b/test/Baseline.Filesystem.Tests.DependencyInjection/SimpleDependencyInjectionTests.cs
@@ -44,7 +44,7 @@ namespace Baseline.Filesystem.Tests.DependencyInjection
                     FilePath = filePath
                 }
             );
-            fileContents.Should().Be("hello, world");
+            fileContents.FileContents.Should().Be("hello, world");
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace Baseline.Filesystem.Tests.DependencyInjection
                     FilePath = filePath
                 }
             );
-            fileContents.Should().Be("hello, world");
+            fileContents.FileContents.Should().Be("hello, world");
         }
         
         [Fact]
@@ -134,7 +134,7 @@ namespace Baseline.Filesystem.Tests.DependencyInjection
                 },
                 "second"
             );
-            fileContents.Should().Be("hello, world");
+            fileContents.FileContents.Should().Be("hello, world");
         }
         [Fact]
         public async Task It_Functions_Correctly_When_A_Root_Path_Is_Registered()
@@ -174,7 +174,7 @@ namespace Baseline.Filesystem.Tests.DependencyInjection
                     FilePath = filePath
                 }
             );
-            fileContents.Should().Be("hello, world");
+            fileContents.FileContents.Should().Be("hello, world");
         }
     }
 }

--- a/test/Baseline.Filesystem.Tests/FileManagerTests/CopyTests.cs
+++ b/test/Baseline.Filesystem.Tests/FileManagerTests/CopyTests.cs
@@ -92,7 +92,7 @@ namespace Baseline.Filesystem.Tests.FileManagerTests
             // Arrange.
             Adapter
                 .Setup(x => x.CopyFileAsync(It.IsAny<CopyFileRequest>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new FileRepresentation())
+                .ReturnsAsync(new CopyFileResponse())
                 .Verifiable();
             
             // Act.

--- a/test/Baseline.Filesystem.Tests/FileManagerTests/ExistsTests.cs
+++ b/test/Baseline.Filesystem.Tests/FileManagerTests/ExistsTests.cs
@@ -61,14 +61,14 @@ namespace Baseline.Filesystem.Tests.FileManagerTests
             // Arrange.
             Adapter
                 .Setup(x => x.FileExistsAsync(It.IsAny<FileExistsRequest>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(false)
+                .ReturnsAsync(new FileExistsResponse { FileExists = false })
                 .Verifiable();
             
             // Act.
             var response = await FileManager.ExistsAsync(new FileExistsRequest { FilePath = "a".AsBaselineFilesystemPath() });
             
             // Assert.
-            response.Should().BeFalse();
+            response.FileExists.Should().BeFalse();
             Adapter.VerifyAll();
         }
     }

--- a/test/Baseline.Filesystem.Tests/FileManagerTests/GetTests.cs
+++ b/test/Baseline.Filesystem.Tests/FileManagerTests/GetTests.cs
@@ -61,7 +61,7 @@ namespace Baseline.Filesystem.Tests.FileManagerTests
             // Arrange.
             Adapter
                 .Setup(x => x.GetFileAsync(It.IsAny<GetFileRequest>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new FileRepresentation { Path = new PathRepresentation() })
+                .ReturnsAsync(new GetFileResponse { File = new FileRepresentation { Path = new PathRepresentation() } })
                 .Verifiable();
             
             // Act.

--- a/test/Baseline.Filesystem.Tests/FileManagerTests/MoveTests.cs
+++ b/test/Baseline.Filesystem.Tests/FileManagerTests/MoveTests.cs
@@ -92,7 +92,7 @@ namespace Baseline.Filesystem.Tests.FileManagerTests
             // Arrange.
             Adapter
                 .Setup(x => x.MoveFileAsync(It.IsAny<MoveFileRequest>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new FileRepresentation())
+                .ReturnsAsync(new MoveFileResponse { DestinationFile = new FileRepresentation() })
                 .Verifiable();
             
             // Act.

--- a/test/Baseline.Filesystem.Tests/FileManagerTests/ReadAsStringTests.cs
+++ b/test/Baseline.Filesystem.Tests/FileManagerTests/ReadAsStringTests.cs
@@ -14,7 +14,7 @@ namespace Baseline.Filesystem.Tests.FileManagerTests
         {
             // Act.
             Func<Task> func = async () => await FileManager.ReadAsStringAsync(
-                new ReadFileAsStringRequest { FilePath = "a".AsBaselineFilesystemPath() },
+                new ReadFileAsStringRequest {FilePath = "a".AsBaselineFilesystemPath()},
                 "foo"
             );
             
@@ -56,23 +56,23 @@ namespace Baseline.Filesystem.Tests.FileManagerTests
             // Assert.
             await func.Should().ThrowExactlyAsync<PathIsADirectoryException>();
         }
-        
+
         [Fact]
         public async Task It_Invokes_The_Matching_Adapters_ReadFileAsString_Method()
         {
             // Arrange.
             Adapter
                 .Setup(x => x.ReadFileAsStringAsync(It.IsAny<ReadFileAsStringRequest>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync("foo")
+                .ReturnsAsync(new ReadFileAsStringResponse {FileContents = "foo"})
                 .Verifiable();
             
             // Act.
             var response = await FileManager.ReadAsStringAsync(
-                new ReadFileAsStringRequest { FilePath = "a".AsBaselineFilesystemPath() }
+                new ReadFileAsStringRequest {FilePath = "a".AsBaselineFilesystemPath()}
             );
             
             // Assert.
-            response.Should().Be("foo");
+            response.FileContents.Should().Be("foo");
             Adapter.VerifyAll();
         }
     }

--- a/test/Baseline.Filesystem.Tests/FileManagerTests/TouchTests.cs
+++ b/test/Baseline.Filesystem.Tests/FileManagerTests/TouchTests.cs
@@ -14,7 +14,7 @@ namespace Baseline.Filesystem.Tests.FileManagerTests
         {
             // Act.
             Func<Task> func = async () => await FileManager.TouchAsync(
-                new TouchFileRequest { FilePath = "a".AsBaselineFilesystemPath() },
+                new TouchFileRequest {FilePath = "a".AsBaselineFilesystemPath()},
                 "foo"
             );
             
@@ -54,14 +54,14 @@ namespace Baseline.Filesystem.Tests.FileManagerTests
             // Assert.
             await func.Should().ThrowExactlyAsync<PathIsADirectoryException>();
         }
-        
+
         [Fact]
         public async Task It_Invokes_The_Matching_Adapters_Touch_File_Method()
         {
             // Arrange.
             Adapter
                 .Setup(x => x.TouchFileAsync(It.IsAny<TouchFileRequest>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new FileRepresentation { Path = new PathRepresentation() })
+                .ReturnsAsync(new TouchFileResponse {File = new FileRepresentation {Path = new PathRepresentation()}})
                 .Verifiable();
             
             // Act.

--- a/test/Baseline.Filesystem.Tests/Fixtures/SuccessfulOutcomeAdapter.cs
+++ b/test/Baseline.Filesystem.Tests/Fixtures/SuccessfulOutcomeAdapter.cs
@@ -10,9 +10,9 @@ namespace Baseline.Filesystem.Tests.Fixtures
             return Task.FromResult(new DirectoryRepresentation());
         }
 
-        public Task<FileRepresentation> CopyFileAsync(CopyFileRequest copyFileRequest, CancellationToken cancellationToken)
+        public Task<CopyFileResponse> CopyFileAsync(CopyFileRequest copyFileRequest, CancellationToken cancellationToken)
         {
-            return Task.FromResult(new FileRepresentation());
+            return Task.FromResult(new CopyFileResponse());
         }
 
         public Task<DirectoryRepresentation> CreateDirectoryAsync(CreateDirectoryRequest createDirectoryRequest, CancellationToken cancellationToken)
@@ -30,9 +30,9 @@ namespace Baseline.Filesystem.Tests.Fixtures
             return Task.CompletedTask;
         }
 
-        public Task<bool> FileExistsAsync(FileExistsRequest fileExistsRequest, CancellationToken cancellationToken)
+        public Task<FileExistsResponse> FileExistsAsync(FileExistsRequest fileExistsRequest, CancellationToken cancellationToken)
         {
-            return Task.FromResult(true);
+            return Task.FromResult(new FileExistsResponse { FileExists = true });
         }
 
         public Task<FileRepresentation> GetFileAsync(GetFileRequest getFileRequest, CancellationToken cancellationToken)

--- a/test/Baseline.Filesystem.Tests/Fixtures/SuccessfulOutcomeAdapter.cs
+++ b/test/Baseline.Filesystem.Tests/Fixtures/SuccessfulOutcomeAdapter.cs
@@ -5,9 +5,9 @@ namespace Baseline.Filesystem.Tests.Fixtures
 {
     public class SuccessfulOutcomeAdapter : IAdapter
     {
-        public Task<DirectoryRepresentation> CopyDirectoryAsync(CopyDirectoryRequest copyDirectoryRequest, CancellationToken cancellationToken)
+        public Task<CopyDirectoryResponse> CopyDirectoryAsync(CopyDirectoryRequest copyDirectoryRequest, CancellationToken cancellationToken)
         {
-            return Task.FromResult(new DirectoryRepresentation());
+            return Task.FromResult(new CopyDirectoryResponse());
         }
 
         public Task<CopyFileResponse> CopyFileAsync(CopyFileRequest copyFileRequest, CancellationToken cancellationToken)
@@ -15,19 +15,19 @@ namespace Baseline.Filesystem.Tests.Fixtures
             return Task.FromResult(new CopyFileResponse());
         }
 
-        public Task<DirectoryRepresentation> CreateDirectoryAsync(CreateDirectoryRequest createDirectoryRequest, CancellationToken cancellationToken)
+        public Task<CreateDirectoryResponse> CreateDirectoryAsync(CreateDirectoryRequest createDirectoryRequest, CancellationToken cancellationToken)
         {
-            return Task.FromResult(new DirectoryRepresentation());
+            return Task.FromResult(new CreateDirectoryResponse());
         }
 
-        public Task DeleteDirectoryAsync(DeleteDirectoryRequest deleteDirectoryRequest, CancellationToken cancellationToken)
+        public Task<DeleteDirectoryResponse> DeleteDirectoryAsync(DeleteDirectoryRequest deleteDirectoryRequest, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return Task.FromResult(new DeleteDirectoryResponse());
         }
 
-        public Task DeleteFileAsync(DeleteFileRequest deleteFileRequest, CancellationToken cancellationToken)
+        public Task<DeleteFileResponse> DeleteFileAsync(DeleteFileRequest deleteFileRequest, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return Task.FromResult(new DeleteFileResponse());
         }
 
         public Task<FileExistsResponse> FileExistsAsync(FileExistsRequest fileExistsRequest, CancellationToken cancellationToken)
@@ -35,9 +35,9 @@ namespace Baseline.Filesystem.Tests.Fixtures
             return Task.FromResult(new FileExistsResponse { FileExists = true });
         }
 
-        public Task<FileRepresentation> GetFileAsync(GetFileRequest getFileRequest, CancellationToken cancellationToken)
+        public Task<GetFileResponse> GetFileAsync(GetFileRequest getFileRequest, CancellationToken cancellationToken)
         {
-            return Task.FromResult(new FileRepresentation());
+            return Task.FromResult(new GetFileResponse());
         }
 
         public Task<ListDirectoryContentsResponse> ListDirectoryContentsAsync(ListDirectoryContentsRequest listDirectoryContentsRequest,
@@ -46,30 +46,30 @@ namespace Baseline.Filesystem.Tests.Fixtures
             return Task.FromResult(new ListDirectoryContentsResponse());
         }
 
-        public Task<DirectoryRepresentation> MoveDirectoryAsync(MoveDirectoryRequest moveDirectoryRequest, CancellationToken cancellationToken)
+        public Task<MoveDirectoryResponse> MoveDirectoryAsync(MoveDirectoryRequest moveDirectoryRequest, CancellationToken cancellationToken)
         {
-            return Task.FromResult(new DirectoryRepresentation());
+            return Task.FromResult(new MoveDirectoryResponse());
         }
 
-        public Task<FileRepresentation> MoveFileAsync(MoveFileRequest moveFileRequest, CancellationToken cancellationToken)
+        public Task<MoveFileResponse> MoveFileAsync(MoveFileRequest moveFileRequest, CancellationToken cancellationToken)
         {
-            return Task.FromResult(new FileRepresentation());
+            return Task.FromResult(new MoveFileResponse());
         }
 
-        public Task<string> ReadFileAsStringAsync(
+        public Task<ReadFileAsStringResponse> ReadFileAsStringAsync(
             ReadFileAsStringRequest readFileAsStringRequest,
             CancellationToken cancellationToken
         )
         {
-            return Task.FromResult("file contents");
+            return Task.FromResult(new ReadFileAsStringResponse { FileContents = "file contents" });
         }
 
-        public Task<FileRepresentation> TouchFileAsync(
+        public Task<TouchFileResponse> TouchFileAsync(
             TouchFileRequest touchFileRequest,
             CancellationToken cancellationToken
         )
         {
-            return Task.FromResult(new FileRepresentation());
+            return Task.FromResult(new TouchFileResponse());
         }
 
         public Task<WriteStreamToFileResponse> WriteStreamToFileAsync(
@@ -80,12 +80,12 @@ namespace Baseline.Filesystem.Tests.Fixtures
             return Task.FromResult(new WriteStreamToFileResponse());
         }
 
-        public Task WriteTextToFileAsync(
+        public Task<WriteTextToFileResponse> WriteTextToFileAsync(
             WriteTextToFileRequest writeTextToFileRequest,
             CancellationToken cancellationToken
         )
         {
-            return Task.CompletedTask;
+            return Task.FromResult(new WriteTextToFileResponse());
         }
 
         public Task<GetFilePublicUrlResponse> GetFilePublicUrlAsync(

--- a/test/Baseline.Filesystem.Tests/GeneralTests.cs
+++ b/test/Baseline.Filesystem.Tests/GeneralTests.cs
@@ -56,7 +56,7 @@ namespace Baseline.Filesystem.Tests
                         It.IsAny<CancellationToken>()
                     )
                 )
-                .ReturnsAsync(true)
+                .ReturnsAsync(new FileExistsResponse { FileExists = true })
                 .Verifiable();
 
             // Act.


### PR DESCRIPTION
In order to future proof and prevent breaking changes resulting from additional info needing to be returned this MR creates unique and custom response models for each method (i.e. `CopyFileResponse` for the copy file method).

Resolves #21