### PR TITLE
Remove root paths from responses

### DIFF
--- a/src/Baseline.Filesystem/BaseAdapterWrapperManager.cs
+++ b/src/Baseline.Filesystem/BaseAdapterWrapperManager.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using Baseline.Filesystem.Internal.Extensions;
+
 namespace Baseline.Filesystem
 {
     /// <summary>

--- a/src/Baseline.Filesystem/DirectoryManager.cs
+++ b/src/Baseline.Filesystem/DirectoryManager.cs
@@ -34,6 +34,11 @@ namespace Baseline.Filesystem
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
+                .RemoveRootPathsAsync(
+                    x => x.DestinationDirectory.Path, 
+                    (o, p) => o.DestinationDirectory.Path = p, 
+                    GetAdapterRootPath(adapter)
+                )
                 .ConfigureAwait(false);
         }
 
@@ -52,6 +57,11 @@ namespace Baseline.Filesystem
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
+                .RemoveRootPathsAsync(
+                    r => r.Directory.Path,
+                    (r, p) => r.Directory.Path = p,
+                    GetAdapterRootPath(adapter)
+                )
                 .ConfigureAwait(false);
         }
 
@@ -92,7 +102,7 @@ namespace Baseline.Filesystem
                         await iterateDirectoryContentsRequest.Action(path);
                         return;
                     }
-
+                    
                     var pathWithoutRoot = new[] {path}.RemoveRootPath(GetAdapterRootPath(adapter)).ToList();
                     if (pathWithoutRoot.Any())
                     {
@@ -119,23 +129,18 @@ namespace Baseline.Filesystem
         {
             BaseSingleDirectoryRequestValidator.ValidateAndThrowIfUnsuccessful(listDirectoryContentsRequest);
 
-            var response = await GetAdapter(adapter)
+            return await GetAdapter(adapter)
                 .ListDirectoryContentsAsync(
                     listDirectoryContentsRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
+                .RemoveRootPathsAsync(
+                    r => r.Contents,
+                    (ri, p) => ri.Contents = p.ToList(),
+                    GetAdapterRootPath(adapter)
+                )
                 .ConfigureAwait(false);
-
-            if (!AdapterHasRootPath(adapter))
-            {
-                return response;
-            }
-
-            return new ListDirectoryContentsResponse
-            {
-                Contents = response.Contents.RemoveRootPath(GetAdapterRootPath(adapter)).ToList()
-            };
         }
 
         /// <inheritdoc />
@@ -153,6 +158,11 @@ namespace Baseline.Filesystem
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
+                .RemoveRootPathsAsync(
+                    r => r.DestinationDirectory.Path,
+                    (r, p) => r.DestinationDirectory.Path = p,
+                    GetAdapterRootPath(adapter)
+                )
                 .ConfigureAwait(false);
         }
     }

--- a/src/Baseline.Filesystem/FileManager.cs
+++ b/src/Baseline.Filesystem/FileManager.cs
@@ -33,6 +33,11 @@ namespace Baseline.Filesystem
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
+                .RemoveRootPathsAsync(
+                    r => r.DestinationFile.Path,
+                    (r, p) => r.DestinationFile.Path = p,
+                    GetAdapterRootPath(adapter)
+                )
                 .ConfigureAwait(false);
         }
 
@@ -87,6 +92,11 @@ namespace Baseline.Filesystem
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
+                .RemoveRootPathsAsync(
+                    r => r.File.Path,
+                    (r, p) => r.File.Path = p,
+                    GetAdapterRootPath(adapter)
+                )
                 .ConfigureAwait(false);
         }
 

--- a/src/Baseline.Filesystem/FileManager.cs
+++ b/src/Baseline.Filesystem/FileManager.cs
@@ -133,6 +133,11 @@ namespace Baseline.Filesystem
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
+                .RemoveRootPathsAsync(
+                    r => r.DestinationFile.Path,
+                    (r, p) => r.DestinationFile.Path = p,
+                    GetAdapterRootPath(adapter)
+                )
                 .ConfigureAwait(false);
         }
 
@@ -187,6 +192,11 @@ namespace Baseline.Filesystem
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
+                .RemoveRootPathsAsync(
+                    r => r.File.Path,
+                    (r, p) => r.File.Path = p,
+                    GetAdapterRootPath(adapter)
+                )
                 .ConfigureAwait(false);
         }
 

--- a/src/Baseline.Filesystem/Internal/Extensions/PathRepresentationExtensions.cs
+++ b/src/Baseline.Filesystem/Internal/Extensions/PathRepresentationExtensions.cs
@@ -9,6 +9,20 @@ namespace Baseline.Filesystem.Internal.Extensions
     internal static class PathRepresentationExtensions
     {
         /// <summary>
+        /// Removes the root path from an single path representations.
+        /// </summary>
+        /// <param name="source">A path representation to remove the root path from.</param>
+        /// <param name="rootPath">The root path to remove.</param>
+        /// <returns>A new path with the root path removed.</returns>
+        public static PathRepresentation RemoveRootPath(
+            this PathRepresentation source,
+            PathRepresentation rootPath
+        )
+        {
+            return new[] {source}.RemoveRootPath(rootPath).First();
+        }
+        
+        /// <summary>
         /// Removes the root path from an enumerable collection of path representations.
         /// </summary>
         /// <param name="source">A collection of path representations to remove the root path from.</param>

--- a/src/Baseline.Filesystem/Internal/Extensions/RootPathRemovalExtensions.cs
+++ b/src/Baseline.Filesystem/Internal/Extensions/RootPathRemovalExtensions.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Baseline.Filesystem.Internal.Extensions
+{
+    internal static class RootPathRemovalExtensions
+    {
+        /// <summary>
+        /// Remove a root path from a single object with a path and return it with that root path removed. If no root
+        /// path is present for the adapter, the original object is returned.
+        /// </summary>
+        /// <param name="obj">The object that has a path that might contain the root path.</param>
+        /// <param name="getter">A lambda used to retrieve the value to modify.</param>
+        /// <param name="setter">A lambda used to set the value that was modified.</param>
+        internal static async Task<TResponse> RemoveRootPathsAsync<TResponse>(
+            this Task<TResponse> obj, 
+            Func<TResponse, PathRepresentation> getter, 
+            Action<TResponse, PathRepresentation> setter,
+            PathRepresentation rootPath
+        )
+        {
+            var objResult = await obj;
+            
+            if (rootPath == null)
+            {
+                return objResult;
+            }
+            
+            var withPathRemoved = getter(objResult).RemoveRootPath(rootPath);
+            setter(objResult, withPathRemoved);
+
+            return objResult;
+        }
+
+        /// <summary>
+        /// Removes the root path from a collection of objects that may have a root path.
+        /// </summary>
+        /// <param name="obj">The entity that contains root paths that need removing.</param>
+        /// <param name="getter">A selector to use to retrieve the path that needs modifying.</param>
+        /// <param name="setter">A function used to modify the path of an entity.</param>
+        internal static async Task<TResponse> RemoveRootPathsAsync<TResponse>(
+            this Task<TResponse> obj, 
+            Func<TResponse, IEnumerable<PathRepresentation>> getter, 
+            Action<TResponse, IEnumerable<PathRepresentation>> setter,
+            PathRepresentation rootPath
+        )
+        {
+            var objResult = await obj;
+            
+            if (rootPath == null)
+            {
+                return objResult;
+            }
+            
+            var withPathRemoved = getter(objResult).RemoveRootPath(rootPath);
+            setter(objResult, withPathRemoved);
+
+            return objResult;
+        }
+    }
+}
+

--- a/src/Baseline.Filesystem/Internal/Extensions/RootPathRemovalExtensions.cs
+++ b/src/Baseline.Filesystem/Internal/Extensions/RootPathRemovalExtensions.cs
@@ -4,6 +4,9 @@ using System.Threading.Tasks;
 
 namespace Baseline.Filesystem.Internal.Extensions
 {
+    /// <summary>
+    /// Extension methods related to the removal of root paths from <see cref="PathRepresentation"/> instances.
+    /// </summary>
     internal static class RootPathRemovalExtensions
     {
         /// <summary>
@@ -13,6 +16,7 @@ namespace Baseline.Filesystem.Internal.Extensions
         /// <param name="obj">The object that has a path that might contain the root path.</param>
         /// <param name="getter">A lambda used to retrieve the value to modify.</param>
         /// <param name="setter">A lambda used to set the value that was modified.</param>
+        /// <param name="rootPath">The root path of the adapter (if present).</param>
         internal static async Task<TResponse> RemoveRootPathsAsync<TResponse>(
             this Task<TResponse> obj, 
             Func<TResponse, PathRepresentation> getter, 
@@ -39,6 +43,7 @@ namespace Baseline.Filesystem.Internal.Extensions
         /// <param name="obj">The entity that contains root paths that need removing.</param>
         /// <param name="getter">A selector to use to retrieve the path that needs modifying.</param>
         /// <param name="setter">A function used to modify the path of an entity.</param>
+        /// <param name="rootPath">The root path of the adapter (if present).</param>
         internal static async Task<TResponse> RemoveRootPathsAsync<TResponse>(
             this Task<TResponse> obj, 
             Func<TResponse, IEnumerable<PathRepresentation>> getter, 

--- a/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/BaseS3AdapterIntegrationTest.cs
+++ b/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/BaseS3AdapterIntegrationTest.cs
@@ -121,11 +121,6 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration
             return $"{(RootPath ?? string.Empty)}{path.NormalisedPath}";
         }
 
-        protected PathRepresentation CombinedPathWithRootPathForAssertion(PathRepresentation path)
-        {
-            return RootPath == null ? path : new PathCombinationBuilder(RootPath.AsBaselineFilesystemPath(), path).Build();
-        }
-
         protected static string RandomDirectoryPath(bool includeBlank = false)
         {
             var directories = new[]

--- a/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Directories/CreateDirectoryTests.cs
+++ b/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Directories/CreateDirectoryTests.cs
@@ -57,7 +57,7 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Directories
                 .Directory
                 .Path
                 .Should()
-                .BeEquivalentTo(CombinedPathWithRootPathForAssertion(directory), x => x.Excluding(y => y.GetPathTree));
+                .BeEquivalentTo(directory, x => x.Excluding(y => y.GetPathTree));
         }
     }
 }

--- a/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Files/GetFileTests.cs
+++ b/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Files/GetFileTests.cs
@@ -39,17 +39,18 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Files
             ReconfigureManagerInstances(true);
             
             var path = RandomFilePathRepresentation();
+            
+            await CreateFileAndWriteTextAsync(path);
 
             // Act.
-            await CreateFileAndWriteTextAsync(path);
+            var response = await FileManager.GetAsync(new GetFileRequest {FilePath = path});
             
             // Assert.
-            var response = await FileManager.GetAsync(new GetFileRequest {FilePath = path});
             response
                 .File
                 .Path
                 .Should()
-                .BeEquivalentTo(CombinedPathWithRootPathForAssertion(path), x => x.Excluding(y => y.GetPathTree));
+                .BeEquivalentTo(path, x => x.Excluding(y => y.GetPathTree));
         }
     }
 }

--- a/test/Baseline.Filesystem.Tests/BaseManagerUsageTest.cs
+++ b/test/Baseline.Filesystem.Tests/BaseManagerUsageTest.cs
@@ -1,13 +1,15 @@
 using Moq;
 
+#nullable enable
+
 namespace Baseline.Filesystem.Tests
 {
     public abstract class BaseManagerUsageTest
     {
-        protected Mock<IAdapter> Adapter { get; set; }
-        protected IAdapterManager AdapterManager { get; set; }
-        protected IFileManager FileManager { get; set; }
-        protected IDirectoryManager DirectoryManager { get; set; }
+        protected Mock<IAdapter> Adapter { get; set; } = null!;
+        protected IAdapterManager AdapterManager { get; set; } = null!;
+        protected IFileManager FileManager { get; set; } = null!;
+        protected IDirectoryManager DirectoryManager { get; set; } = null!;
 
         protected BaseManagerUsageTest()
         {

--- a/test/Baseline.Filesystem.Tests/DirectoryManagerTests/MoveTests.cs
+++ b/test/Baseline.Filesystem.Tests/DirectoryManagerTests/MoveTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Moq;
 using Xunit;
 
 namespace Baseline.Filesystem.Tests.DirectoryManagerTests
@@ -83,6 +85,30 @@ namespace Baseline.Filesystem.Tests.DirectoryManagerTests
             
             // Assert.
             await func.Should().ThrowExactlyAsync<PathIsNotObviouslyADirectoryException>();
+        }
+        
+        [Fact]
+        public async Task It_Removes_A_Root_Path_Returned_From_The_Adapter()
+        {
+            // Arrange.
+            Reconfigure(true);
+
+            Adapter.Setup(x => x.MoveDirectoryAsync(It.IsAny<MoveDirectoryRequest>(), CancellationToken.None))
+                .ReturnsAsync(new MoveDirectoryResponse
+                {
+                    DestinationDirectory = new DirectoryRepresentation { Path = $"root/a/b/".AsBaselineFilesystemPath() }
+                });
+
+            // Act.
+            var response = await DirectoryManager.MoveAsync(new MoveDirectoryRequest
+            {
+                SourceDirectoryPath = "a/a/".AsBaselineFilesystemPath(),
+                DestinationDirectoryPath = "a/b/".AsBaselineFilesystemPath()
+            });
+
+            // Assert.
+            response.DestinationDirectory.Path.NormalisedPath.Should().NotContain("root");
+            response.DestinationDirectory.Path.OriginalPath.Should().Be("a/b/");
         }
     }
 }

--- a/test/Baseline.Filesystem.Tests/FileManagerTests/CopyTests.cs
+++ b/test/Baseline.Filesystem.Tests/FileManagerTests/CopyTests.cs
@@ -103,5 +103,29 @@ namespace Baseline.Filesystem.Tests.FileManagerTests
             // Assert.
             Adapter.VerifyAll();
         }
+        
+        [Fact]
+        public async Task It_Removes_A_Root_Path_Returned_From_The_Adapter()
+        {
+            // Arrange.
+            Reconfigure(true);
+
+            Adapter.Setup(x => x.CopyFileAsync(It.IsAny<CopyFileRequest>(), CancellationToken.None))
+                .ReturnsAsync(new CopyFileResponse
+                {
+                    DestinationFile = new FileRepresentation { Path = $"root/a/b/c.txt".AsBaselineFilesystemPath() }
+                });
+
+            // Act.
+            var response = await FileManager.CopyAsync(new CopyFileRequest
+            {
+                SourceFilePath = "a/b/a.txt".AsBaselineFilesystemPath(),
+                DestinationFilePath = "a/b/c.txt".AsBaselineFilesystemPath()
+            });
+
+            // Assert.
+            response.DestinationFile.Path.NormalisedPath.Should().NotContain("root");
+            response.DestinationFile.Path.OriginalPath.Should().Be("a/b/c.txt");
+        }
     }
 }

--- a/test/Baseline.Filesystem.Tests/FileManagerTests/GetTests.cs
+++ b/test/Baseline.Filesystem.Tests/FileManagerTests/GetTests.cs
@@ -70,5 +70,28 @@ namespace Baseline.Filesystem.Tests.FileManagerTests
             // Assert.
             Adapter.VerifyAll();
         }
+        
+        [Fact]
+        public async Task It_Removes_A_Root_Path_Returned_From_The_Adapter()
+        {
+            // Arrange.
+            Reconfigure(true);
+
+            Adapter.Setup(x => x.GetFileAsync(It.IsAny<GetFileRequest>(), CancellationToken.None))
+                .ReturnsAsync(new GetFileResponse
+                {
+                    File = new FileRepresentation { Path = $"root/a/b/c.txt".AsBaselineFilesystemPath() }
+                });
+
+            // Act.
+            var response = await FileManager.GetAsync(new GetFileRequest
+            {
+                FilePath = "a/b/c.txt".AsBaselineFilesystemPath(),
+            });
+
+            // Assert.
+            response.File.Path.NormalisedPath.Should().NotContain("root");
+            response.File.Path.OriginalPath.Should().Be("a/b/c.txt");
+        }
     }
 }

--- a/test/Baseline.Filesystem.Tests/FileManagerTests/MoveTests.cs
+++ b/test/Baseline.Filesystem.Tests/FileManagerTests/MoveTests.cs
@@ -103,5 +103,29 @@ namespace Baseline.Filesystem.Tests.FileManagerTests
             // Assert.
             Adapter.VerifyAll();
         }
+        
+        [Fact]
+        public async Task It_Removes_A_Root_Path_Returned_From_The_Adapter()
+        {
+            // Arrange.
+            Reconfigure(true);
+
+            Adapter.Setup(x => x.MoveFileAsync(It.IsAny<MoveFileRequest>(), CancellationToken.None))
+                .ReturnsAsync(new MoveFileResponse
+                {
+                    DestinationFile = new FileRepresentation { Path = $"root/a/b/c.txt".AsBaselineFilesystemPath() }
+                });
+
+            // Act.
+            var response = await FileManager.MoveAsync(new MoveFileRequest
+            {
+                SourceFilePath = "a/b/a.txt".AsBaselineFilesystemPath(),
+                DestinationFilePath = "a/b/c.txt".AsBaselineFilesystemPath(),
+            });
+
+            // Assert.
+            response.DestinationFile.Path.NormalisedPath.Should().NotContain("root");
+            response.DestinationFile.Path.OriginalPath.Should().Be("a/b/c.txt");
+        }
     }
 }

--- a/test/Baseline.Filesystem.Tests/FileManagerTests/TouchTests.cs
+++ b/test/Baseline.Filesystem.Tests/FileManagerTests/TouchTests.cs
@@ -70,5 +70,28 @@ namespace Baseline.Filesystem.Tests.FileManagerTests
             // Assert.
             Adapter.VerifyAll();
         }
+        
+        [Fact]
+        public async Task It_Removes_A_Root_Path_Returned_From_The_Adapter()
+        {
+            // Arrange.
+            Reconfigure(true);
+
+            Adapter.Setup(x => x.TouchFileAsync(It.IsAny<TouchFileRequest>(), CancellationToken.None))
+                .ReturnsAsync(new TouchFileResponse
+                {
+                    File = new FileRepresentation { Path = $"root/a/b/c.txt".AsBaselineFilesystemPath() }
+                });
+
+            // Act.
+            var response = await FileManager.TouchAsync(new TouchFileRequest
+            {
+                FilePath = "a/b/c.txt".AsBaselineFilesystemPath(),
+            });
+
+            // Assert.
+            response.File.Path.NormalisedPath.Should().NotContain("root");
+            response.File.Path.OriginalPath.Should().Be("a/b/c.txt");
+        }
     }
 }


### PR DESCRIPTION
Removes occurrences of root paths from any responses (provided an adapter has a root path configured and that occurrence contains that root path).

Resolves #26 