### PR TITLE
Issue #40 - Add the ability to exit a directory contents iteration call.

### DIFF
--- a/src/Baseline.Filesystem.Adapters.S3/S3Adapter.Directory.cs
+++ b/src/Baseline.Filesystem.Adapters.S3/S3Adapter.Directory.cs
@@ -94,7 +94,7 @@ namespace Baseline.Filesystem
 
             await ListPaginatedFilesUnderPathAndPerformActionUntilCompleteAsync(
                 iterateDirectoryContentsRequest.DirectoryPath,
-                async r =>
+                async (r, exit) =>
                 {
                     var pathTracker = new Dictionary<string, PathRepresentation>();
                     foreach (var file in r.S3Objects)
@@ -102,7 +102,7 @@ namespace Baseline.Filesystem
                         var tree = BuildOrderedPathTree(file.Key.AsBaselineFilesystemPath(), pathTracker);
                         foreach (var treeItem in tree)
                         {
-                            await iterateDirectoryContentsRequest.Action(treeItem);    
+                            await iterateDirectoryContentsRequest.Action(treeItem, exit);    
                         }
                     }
                 },
@@ -126,7 +126,7 @@ namespace Baseline.Filesystem
 
             await ListPaginatedFilesUnderPathAndPerformActionUntilCompleteAsync(
                 listDirectoryContentsRequest.DirectoryPath,
-                r =>
+                (r, _) =>
                 {
                     r.S3Objects.ForEach(
                         o => directorysContents.AddRange(

--- a/src/Baseline.Filesystem/DirectoryManager.cs
+++ b/src/Baseline.Filesystem/DirectoryManager.cs
@@ -95,18 +95,18 @@ namespace Baseline.Filesystem
             var request = new IterateDirectoryContentsRequest
             {
                 DirectoryPath = iterateDirectoryContentsRequest.DirectoryPath,
-                Action = async path =>
+                Action = async (path, exit) =>
                 {
                     if (!StoreHasRootPath(store))
                     {
-                        await iterateDirectoryContentsRequest.Action(path);
+                        await iterateDirectoryContentsRequest.Action(path, exit);
                         return;
                     }
                     
                     var pathWithoutRoot = new[] {path}.RemoveRootPath(GetStoreRootPath(store)).ToList();
                     if (pathWithoutRoot.Any())
                     {
-                        await iterateDirectoryContentsRequest.Action(pathWithoutRoot.First());   
+                        await iterateDirectoryContentsRequest.Action(pathWithoutRoot.First(), exit);   
                     }
                 }
             };

--- a/src/Baseline.Filesystem/DirectoryManager.cs
+++ b/src/Baseline.Filesystem/DirectoryManager.cs
@@ -95,19 +95,20 @@ namespace Baseline.Filesystem
             var request = new IterateDirectoryContentsRequest
             {
                 DirectoryPath = iterateDirectoryContentsRequest.DirectoryPath,
-                Action = async (path, exit) =>
+                Action = async path =>
                 {
                     if (!StoreHasRootPath(store))
                     {
-                        await iterateDirectoryContentsRequest.Action(path, exit);
-                        return;
+                        return await iterateDirectoryContentsRequest.Action(path);
                     }
                     
                     var pathWithoutRoot = new[] {path}.RemoveRootPath(GetStoreRootPath(store)).ToList();
                     if (pathWithoutRoot.Any())
                     {
-                        await iterateDirectoryContentsRequest.Action(pathWithoutRoot.First(), exit);   
+                        return await iterateDirectoryContentsRequest.Action(pathWithoutRoot.First());
                     }
+
+                    return true;
                 }
             };
 

--- a/src/Baseline.Filesystem/Requests/Directory/IterateDirectoryContentsRequest.cs
+++ b/src/Baseline.Filesystem/Requests/Directory/IterateDirectoryContentsRequest.cs
@@ -4,14 +4,20 @@ using System.Threading.Tasks;
 namespace Baseline.Filesystem
 {
     /// <summary>
+    /// A delegate signature used to exit the iteration of a directory's contents.
+    /// </summary>
+    public delegate void ExitIteration();
+    
+    /// <summary>
     /// Request used to iterate over the contents of a directory in a performant manner.
     /// </summary>
     public class IterateDirectoryContentsRequest : BaseSingleDirectoryRequest<IterateDirectoryContentsRequest>
     {
         /// <summary>
-        /// Gets or sets the action to perform on each file or directory within the requested directory.
+        /// Gets or sets a delegate to perform on each file or directory within the requested directory. The delegate's
+        /// second parameter of type ExitIteration allows you to exit the loop at the end of the current iteration.
         /// </summary>
-        public Func<PathRepresentation, Task> Action { get; set; }
+        public Func<PathRepresentation, ExitIteration, Task> Action { get; set; }
 
         /// <inheritdoc />
         internal override IterateDirectoryContentsRequest ShallowClone()

--- a/src/Baseline.Filesystem/Requests/Directory/IterateDirectoryContentsRequest.cs
+++ b/src/Baseline.Filesystem/Requests/Directory/IterateDirectoryContentsRequest.cs
@@ -4,20 +4,15 @@ using System.Threading.Tasks;
 namespace Baseline.Filesystem
 {
     /// <summary>
-    /// A delegate signature used to exit the iteration of a directory's contents.
-    /// </summary>
-    public delegate void ExitIteration();
-    
-    /// <summary>
     /// Request used to iterate over the contents of a directory in a performant manner.
     /// </summary>
     public class IterateDirectoryContentsRequest : BaseSingleDirectoryRequest<IterateDirectoryContentsRequest>
     {
         /// <summary>
-        /// Gets or sets a delegate to perform on each file or directory within the requested directory. The delegate's
-        /// second parameter of type ExitIteration allows you to exit the loop at the end of the current iteration.
+        /// Gets or sets a delegate to perform on each file or directory within the requested directory. Returning a
+        /// `false` boolean from the delegate will stop iterating further.
         /// </summary>
-        public Func<PathRepresentation, ExitIteration, Task> Action { get; set; }
+        public Func<PathRepresentation, Task<bool>> Action { get; set; }
 
         /// <inheritdoc />
         internal override IterateDirectoryContentsRequest ShallowClone()

--- a/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Directories/IterateDirectoryContentsTests.cs
+++ b/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Directories/IterateDirectoryContentsTests.cs
@@ -21,10 +21,10 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Directories
             await DirectoryManager.IterateContentsAsync(new IterateDirectoryContentsRequest
             {
                 DirectoryPath = "simple/".AsBaselineFilesystemPath(),
-                Action = (paths, _) =>
+                Action = paths =>
                 { 
                     files.Add(paths);
-                    return Task.CompletedTask;
+                    return Task.FromResult(true);
                 }
             });
 
@@ -52,10 +52,10 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Directories
             await DirectoryManager.IterateContentsAsync(new IterateDirectoryContentsRequest
             {
                 DirectoryPath = "a/".AsBaselineFilesystemPath(),
-                Action = (paths, _) =>
+                Action = paths =>
                 {
                     files.Add(paths);
-                    return Task.CompletedTask;
+                    return Task.FromResult(true);
                 }
             });
 
@@ -91,10 +91,10 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Directories
             await DirectoryManager.IterateContentsAsync(new IterateDirectoryContentsRequest
             {
                 DirectoryPath = "a-dir/".AsBaselineFilesystemPath(),
-                Action = (p, _) =>
+                Action = p =>
                 {
                     files.Add(p);
-                    return Task.CompletedTask;
+                    return Task.FromResult(true);
                 }
             });
             
@@ -121,10 +121,10 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Directories
             await DirectoryManager.IterateContentsAsync(new IterateDirectoryContentsRequest
             {
                 DirectoryPath = "simple/".AsBaselineFilesystemPath(),
-                Action = (p, _) =>
+                Action = p =>
                 {
                     files.Add(p);
-                    return Task.CompletedTask;
+                    return Task.FromResult(true);
                 }
             });
 
@@ -154,10 +154,10 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Directories
             await DirectoryManager.IterateContentsAsync(new IterateDirectoryContentsRequest
             {
                 DirectoryPath = "a/".AsBaselineFilesystemPath(),
-                Action = (p, _) =>
+                Action = p =>
                 {
                     files.Add(p);
-                    return Task.CompletedTask;
+                    return Task.FromResult(true);
                 }
             });
 
@@ -194,16 +194,16 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Directories
             await DirectoryManager.IterateContentsAsync(new IterateDirectoryContentsRequest
             {
                 DirectoryPath = "a/".AsBaselineFilesystemPath(),
-                Action = (p, exit) =>
+                Action = p =>
                 {
                     count += 1;
                     
                     if (count == 2)
                     {
-                        exit();
+                        return Task.FromResult(false);
                     }
 
-                    return Task.CompletedTask;
+                    return Task.FromResult(true);
                 }
             });
 

--- a/test/Baseline.Filesystem.Tests/DirectoryManagerTests/IterateContentsTests.cs
+++ b/test/Baseline.Filesystem.Tests/DirectoryManagerTests/IterateContentsTests.cs
@@ -15,7 +15,7 @@ namespace Baseline.Filesystem.Tests.DirectoryManagerTests
                 new IterateDirectoryContentsRequest
                 {
                     DirectoryPath = "i/am/a/directory/".AsBaselineFilesystemPath(), 
-                    Action = (_, __) => null
+                    Action = (_) => null
                 },
                 "non-existent"
             );
@@ -39,7 +39,7 @@ namespace Baseline.Filesystem.Tests.DirectoryManagerTests
         {
             // Act.
             Func<Task> func = () => DirectoryManager.IterateContentsAsync(
-                new IterateDirectoryContentsRequest { Action = (_, __) => null }
+                new IterateDirectoryContentsRequest { Action = (_) => null }
             );
             
             // Assert.
@@ -53,7 +53,7 @@ namespace Baseline.Filesystem.Tests.DirectoryManagerTests
             Func<Task> func = () => DirectoryManager.IterateContentsAsync(new IterateDirectoryContentsRequest()
             {
                 DirectoryPath = "i/am/not/a/directory/but-a-path.jpeg".AsBaselineFilesystemPath(),
-                Action = (_, __) => null
+                Action = (_) => null
             });
             
             // Assert.

--- a/test/Baseline.Filesystem.Tests/DirectoryManagerTests/IterateContentsTests.cs
+++ b/test/Baseline.Filesystem.Tests/DirectoryManagerTests/IterateContentsTests.cs
@@ -15,7 +15,7 @@ namespace Baseline.Filesystem.Tests.DirectoryManagerTests
                 new IterateDirectoryContentsRequest
                 {
                     DirectoryPath = "i/am/a/directory/".AsBaselineFilesystemPath(), 
-                    Action = _ => null
+                    Action = (_, __) => null
                 },
                 "non-existent"
             );
@@ -39,7 +39,7 @@ namespace Baseline.Filesystem.Tests.DirectoryManagerTests
         {
             // Act.
             Func<Task> func = () => DirectoryManager.IterateContentsAsync(
-                new IterateDirectoryContentsRequest { Action = _ => null }
+                new IterateDirectoryContentsRequest { Action = (_, __) => null }
             );
             
             // Assert.
@@ -53,7 +53,7 @@ namespace Baseline.Filesystem.Tests.DirectoryManagerTests
             Func<Task> func = () => DirectoryManager.IterateContentsAsync(new IterateDirectoryContentsRequest()
             {
                 DirectoryPath = "i/am/not/a/directory/but-a-path.jpeg".AsBaselineFilesystemPath(),
-                Action = _ => null
+                Action = (_, __) => null
             });
             
             // Assert.


### PR DESCRIPTION
* Current logic is to iterate until finished.
* Added a return to the Action delegate that will short-circuit the exit and exit after the current iteration is complete.
* Updated the required tests to function with this new signature.

Resolves #40 